### PR TITLE
Hex view for binaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,3 +200,5 @@ The following people have contributed code to erlyberly:
 + [@aboroska](https://github.com/aboroska)
 + [@ruanpienaar](https://github.com/ruanpienaar)
 + [@horvand ](https://github.com/horvand)
+
+The hex editor originated from [hexstar](https://github.com/Velocity-/Hexstar).

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -1,8 +1,8 @@
 package erlyberly;
 
-import com.ericsson.otp.erlang.OtpErlangException;
 import java.io.IOException;
 
+import erlyberly.node.NodeAPI;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ObservableValue;
@@ -10,17 +10,14 @@ import javafx.event.EventHandler;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.SplitPane;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.SplitPane.Divider;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import erlyberly.node.NodeAPI;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class ErlyBerly extends Application {
 

--- a/src/main/java/erlyberly/PreferencesView.java
+++ b/src/main/java/erlyberly/PreferencesView.java
@@ -2,12 +2,11 @@ package erlyberly;
 
 import java.net.URL;
 import java.util.ResourceBundle;
-import javafx.beans.property.SimpleBooleanProperty;
+
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
-import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -6,6 +6,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangTuple;
 
 import erlyberly.node.OtpUtil;
+import hextstar.HexstarView;
 import javafx.event.ActionEvent;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
@@ -28,9 +29,24 @@ public class TermTreeView extends TreeView<TermTreeItem> {
 
         MenuItem dictMenuItem = new MenuItem("Dict to List");
         dictMenuItem.setOnAction(this::onViewDict);
+        
 
-        setContextMenu(new ContextMenu(copyMenuItem, dictMenuItem));
-}
+        MenuItem hexViewMenuItem = new MenuItem("Hex View");
+        hexViewMenuItem.setOnAction(this::onHexView);
+
+        setContextMenu(new ContextMenu(copyMenuItem, dictMenuItem, hexViewMenuItem));
+    }
+
+    public void onHexView(ActionEvent e) {
+        TreeItem<TermTreeItem> item = getSelectionModel().getSelectedItem();
+        if(item != null && item.getValue().getObject() instanceof OtpErlangBinary) {
+            OtpErlangBinary binary = (OtpErlangBinary) item.getValue().getObject();
+            HexstarView hexstarView;
+            hexstarView = new HexstarView();
+            hexstarView.setBinary(binary);
+            ErlyBerly.subWindow("Hex View", hexstarView);
+        }
+    }
 
     public void onViewDict(ActionEvent e) {
         TreeItem<TermTreeItem> item = getSelectionModel().getSelectedItem();

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -427,16 +427,6 @@ public class TopBarView implements Initializable {
 		
 		hideProcessesButton.setText(buttonText);
 	}
-    
-	private void toggleHideProcs(Boolean preferenceBool) {
-        String buttonText;
-		if(preferenceBool){
-            buttonText = "Hide Processes";
-        }else{
-            buttonText = "Show Processes";
-        }
-        hideProcessesButton.setText(buttonText);
-	}
 	
 	private void toggleHideFuncs() {
 		String buttonText = "";

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -264,17 +264,12 @@ public class NodeAPI {
 	}
 	
 	private void unloadRemoteErlyberly() throws IOException, OtpErlangException {
-		
-		OtpErlangBinary otpErlangBinary = new OtpErlangBinary(loadBeamFile());
-		
         sendRPC("code", "purge", list(atom("erlyberly")));
-		OtpErlangObject result = receiveRPC();
-		
+		receiveRPC();
 		sendRPC("code", "delete", list(atom("erlyberly")));
-		OtpErlangObject result2 = receiveRPC();
-		
+		receiveRPC();
 		sendRPC("code", "soft_purge", list(atom("erlyberly")));
-		OtpErlangObject result3 = receiveRPC();	
+		receiveRPC();
 	}
 
 	private OtpErlangObject receiveRPC() throws IOException, OtpErlangException {

--- a/src/main/java/hextstar/DataRow.java
+++ b/src/main/java/hextstar/DataRow.java
@@ -1,0 +1,102 @@
+package hextstar;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * Created by Bart on 9/26/2015.
+ */
+public class DataRow {
+    private StringProperty address, text;
+    private StringProperty[] data = new StringProperty[16];
+
+    public DataRow(int addr, byte[] b) {
+        address = new SimpleStringProperty(String.format("%08X", addr));
+        text = new SimpleStringProperty();
+        StringBuilder sb = new StringBuilder(16);
+        for (int i = 0; i < b.length; i++) {
+            // display the byte as an unsigned number, like erlang binaries
+            data[i] = new SimpleStringProperty((b[i]& 0xFF) + "");
+            if(b[i] == 10)
+                sb.append("\\n");
+            else if(b[i] >= 32 && b[i] < 127)
+                sb.append((char)b[i]);
+            else
+                sb.append(".");
+        }
+        text.set(sb.toString());
+    }
+
+    public StringProperty addressProperty() {
+        return address;
+    }
+
+    public StringProperty textProperty() {
+        return text;
+    }
+
+    public StringProperty b0Property() {
+        return data[0];
+    }
+
+    public StringProperty b1Property() {
+        return data[1];
+    }
+
+    public StringProperty b2Property() {
+        return data[2];
+    }
+
+    public StringProperty b3Property() {
+        return data[3];
+    }
+
+    public StringProperty b4Property() {
+        return data[4];
+    }
+
+    public StringProperty b5Property() {
+        return data[5];
+    }
+
+    public StringProperty b6Property() {
+        return data[6];
+    }
+
+    public StringProperty b7Property() {
+        return data[7];
+    }
+
+    public StringProperty b8Property() {
+        return data[8];
+    }
+
+    public StringProperty b9Property() {
+        return data[9];
+    }
+
+    public StringProperty bAProperty() {
+        return data[0xA];
+    }
+
+    public StringProperty bBProperty() {
+        return data[0xB];
+    }
+
+    public StringProperty bCProperty() {
+        return data[0xC];
+    }
+
+    public StringProperty bDProperty() {
+        return data[0xD];
+    }
+
+    public StringProperty bEProperty() {
+        return data[0xE];
+    }
+
+    public StringProperty bFProperty() {
+        return data[0xF];
+    }
+}
+

--- a/src/main/java/hextstar/HexstarView.java
+++ b/src/main/java/hextstar/HexstarView.java
@@ -1,0 +1,72 @@
+package hextstar;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+import com.ericsson.otp.erlang.OtpErlangBinary;
+
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+
+/**
+ * Created by Bart on 9/26/2015.
+ * Originally from https://github.com/Velocity-/Hexstar
+ */
+public class HexstarView extends TableView<DataRow> {
+
+    public HexstarView() {
+        //setContextMenu(new ContextMenu(new MenuItem("Copy"), new MenuItem("Cut"), new MenuItem("Delete")));
+        getSelectionModel().setCellSelectionEnabled(true);
+        getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        column("Address", "address");
+        column("0", "b0");
+        column("1", "b1");
+        column("2", "b2");
+        column("3", "b3");
+        column("4", "b4");
+        column("5", "b5");
+        column("6", "b6");
+        column("7", "b7");
+        column("8", "b8");
+        column("9", "b9");
+        column("A", "bA");
+        column("B", "bB");
+        column("C", "bC");
+        column("D", "bD");
+        column("E", "bE");
+        column("F", "bF");
+        column("Text", "text");
+
+        getColumns().forEach(c -> {
+            c.setStyle("-fx-alignment: CENTER; -fx-font-family: monospace;");
+            c.setSortable(false);
+        });
+        getColumns().get(0).setStyle("-fx-alignment: CENTER-RIGHT; -fx-font-family: monospace;");
+    }
+
+    public void setBinary(OtpErlangBinary binary) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(binary.binaryValue());
+        byte[] input = new byte[16];
+        int addr = 0;
+        try {
+            while ((inputStream.read(input)) > 0) {
+                getItems().add(new DataRow(addr += 16, input));
+                Arrays.fill(input, (byte)0);
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    private void column(String colName, String property) {
+        TableColumn<DataRow, String> col;
+        col = new TableColumn<DataRow,String>(colName);
+        col.setCellValueFactory(new PropertyValueFactory<DataRow, String>(property));
+        getColumns().add(col);
+    }
+}


### PR DESCRIPTION
Hex view for binary terms in the term tree view. Right click on a binary term in the expanded arguments and results and click **Hex View** in the menu. Byte values are displayed as unsigned integers instead of hex, which is more commonly written in erlang.

<img width="1074" alt="screen shot 2016-03-01 at 23 07 50" src="https://cloud.githubusercontent.com/assets/213455/13445277/2ae95b34-e003-11e5-8550-98dd68caaecc.png">
