### PR TITLE
Hex view, minor fixes.

### DIFF
--- a/src/main/java/hextstar/DataRow.java
+++ b/src/main/java/hextstar/DataRow.java
@@ -5,18 +5,22 @@ import javafx.beans.property.StringProperty;
 
 /**
  * Created by Bart on 9/26/2015.
+ * Originally from https://github.com/Velocity-/Hexstar
  */
 public class DataRow {
     private StringProperty address, text;
     private StringProperty[] data = new StringProperty[16];
 
-    public DataRow(int addr, byte[] b) {
+    public DataRow(int addr, byte[] b, int bytesRead) {
         address = new SimpleStringProperty(String.format("%08X", addr));
         text = new SimpleStringProperty();
-        StringBuilder sb = new StringBuilder(16);
+        StringBuilder sb = new StringBuilder(bytesRead);
         for (int i = 0; i < b.length; i++) {
+            String stringByteValue = "";
             // display the byte as an unsigned number, like erlang binaries
-            data[i] = new SimpleStringProperty((b[i]& 0xFF) + "");
+            if(i < bytesRead)
+                stringByteValue = Integer.toString((b[i]& 0xFF));
+            data[i] = new SimpleStringProperty(stringByteValue);
             if(b[i] == 10)
                 sb.append("\\n");
             else if(b[i] >= 32 && b[i] < 127)

--- a/src/main/java/hextstar/HexstarView.java
+++ b/src/main/java/hextstar/HexstarView.java
@@ -51,10 +51,11 @@ public class HexstarView extends TableView<DataRow> {
     public void setBinary(OtpErlangBinary binary) {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(binary.binaryValue());
         byte[] input = new byte[16];
-        int addr = 0;
+        int addr = 0, bytesRead = 0;
         try {
-            while ((inputStream.read(input)) > 0) {
-                getItems().add(new DataRow(addr += 16, input));
+            while ((bytesRead = inputStream.read(input)) > 0) {
+                getItems().add(new DataRow(addr, input, bytesRead));
+                addr += 16;
                 Arrays.fill(input, (byte)0);
             }
         }


### PR DESCRIPTION
Make the initial hex view address zero. Show no value for cells not covered by a byte.