### PR TITLE
Miscellaneous Usability Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The process and trace filters support **or** and **not** filters, module filteri
 
 If the filter is empty then all data is shown.
 
+Show functions that are currently traced by setting `#t` as the function filter.
+
 ##### Trace between restarts
 
 When the target node VM gets restarted, erlyberly tries to reconnect and reapply the traces you had previously set.  This is great for your dev workflow.  Make a change, restart and your traces will be there waiting for you to retest.

--- a/src/main/java/erlyberly/CodeView.java
+++ b/src/main/java/erlyberly/CodeView.java
@@ -1,0 +1,20 @@
+package erlyberly;
+
+import javafx.scene.control.TextArea;
+
+public class CodeView extends TextArea {
+    
+    {
+        getStyleClass().add("mod-src");
+        setEditable(false);
+    }
+
+    public CodeView() {
+        super();
+    }
+
+    public CodeView(String text) {
+        super(text);
+    }
+
+}

--- a/src/main/java/erlyberly/ConnectionView.java
+++ b/src/main/java/erlyberly/ConnectionView.java
@@ -42,7 +42,7 @@ public class ConnectionView implements Initializable {
     public void initialize(URL url, ResourceBundle r) {
         PrefBind.bind("targetNodeName", nodeNameField.textProperty());
         PrefBind.bind("cookieName", cookieField.textProperty());
-        PrefBind.bind_boolean("autoConnect", autoConnectField.selectedProperty());
+        PrefBind.bindBoolean("autoConnect", autoConnectField.selectedProperty());
         
         nodeNameField.disableProperty().bind(isConnecting);
         cookieField.disableProperty().bind(isConnecting);

--- a/src/main/java/erlyberly/CrashReportView.java
+++ b/src/main/java/erlyberly/CrashReportView.java
@@ -57,7 +57,10 @@ public class CrashReportView extends TabPane {
                             try {
                                 String source = ErlyBerly.nodeAPI().moduleFunctionSourceCode(
                                         mf.getModuleName(), mf.getFuncName(), mf.getArity());
-                                ErlyBerly.showSourceCodeWindow("Crash Report Stack", source);
+                                ErlyBerly.showPane(
+                                    "Crash Report Stack",
+                                    ErlyBerly.wrapInPane(new CodeView(source))
+                                );
                             } catch (Exception e1) {
                                 e1.printStackTrace();
                             } 

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -222,7 +222,7 @@ public class DbgTraceView extends VBox {
         boolean appendArity = true; // append arity instead of the arguments
         traceLog.appendFunctionToString(sb, appendArity);
         
-        ErlyBerly.showPane(sb.toString(), splitPane);
+        ErlyBerly.showPane(sb.toString(), ErlyBerly.wrapInPane(splitPane));
     }
     
     private Node labelledTreeView(String label, TermTreeView node) {        

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -219,7 +219,7 @@ public class DbgTraceView extends VBox {
         
         StringBuilder sb = new StringBuilder(traceLog.getPidString());
         sb.append(" ");
-        boolean appendArity = false;
+        boolean appendArity = true; // append arity instead of the arguments
         traceLog.appendFunctionToString(sb, appendArity);
         
         ErlyBerly.showPane(sb.toString(), splitPane);

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -14,7 +14,6 @@ import javafx.scene.control.SplitPane;
 import javafx.scene.control.SplitPane.Divider;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
-import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Pane;
@@ -24,7 +23,6 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import ui.CloseWindowOnEscape;
 
 public class ErlyBerly extends Application {
 
@@ -218,32 +216,8 @@ public class ErlyBerly extends Application {
         tabPane.getSelectionModel().select(newTab);
     }
 
-    public static void showSourceCodeWindow(String title, String moduleSourceCode) {
-        assert Platform.isFxApplicationThread();
-        
-        TextArea textArea;
-        
-        textArea = new TextArea(moduleSourceCode);
-        textArea.getStyleClass().add("mod-src");
-        textArea.setEditable(false);
-        
-        Scene scene = new Scene(textArea, 800, 800);
-        ErlyBerly.applyCssToWIndow(scene);
-
-        Stage primaryStage;
-        
-        primaryStage = new Stage();
-        primaryStage.setTitle(title);
-        primaryStage.setScene(scene);
-        primaryStage.show();
-
-        CloseWindowOnEscape.apply(scene, primaryStage);
-    }
-
     /**
      * All I know is pane.
-     * @param node
-     * @return
      */
     public static Pane wrapInPane(Node node) {
         if(node instanceof Pane)

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -7,6 +7,7 @@ import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ObservableValue;
 import javafx.event.EventHandler;
+import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.SplitPane;
@@ -16,6 +17,7 @@ import javafx.scene.control.TabPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
@@ -204,11 +206,10 @@ public class ErlyBerly extends Application {
         return nodeAPI;
     }
 
-
     /**
      * Show a new control in the tab pane. The tab is closable.
      */
-    public static void showPane(String title, Parent parentControl) {
+    public static void showPane(String title, Pane parentControl) {
         assert Platform.isFxApplicationThread();
         Tab newTab;
         newTab = new Tab(title);
@@ -237,5 +238,17 @@ public class ErlyBerly extends Application {
         primaryStage.show();
 
         CloseWindowOnEscape.apply(scene, primaryStage);
+    }
+
+    /**
+     * All I know is pane.
+     * @param node
+     * @return
+     */
+    public static Pane wrapInPane(Node node) {
+        if(node instanceof Pane)
+            return (Pane) node;
+        VBox.setVgrow(node, Priority.ALWAYS);
+        return new VBox(node);
     }
 }

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -249,6 +249,7 @@ public class ErlyBerly extends Application {
         if(node instanceof Pane)
             return (Pane) node;
         VBox.setVgrow(node, Priority.ALWAYS);
-        return new VBox(node);
+        VBox vBox = new VBox(node);
+        return vBox;
     }
 }

--- a/src/main/java/erlyberly/ModFunc.java
+++ b/src/main/java/erlyberly/ModFunc.java
@@ -137,6 +137,10 @@ public class ModFunc implements Comparable<ModFunc> {
             return false;
         return true;
     }
+
+    public boolean isModuleInfo() {
+        return "module_info".equals(funcName) && (arity == 0 || arity == 1);
+    }
     
     
 }

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -278,11 +278,11 @@ public class ModFuncContextMenu extends ContextMenu {
             }
             catch (IOException e) {
                 e.printStackTrace();
-                ErlyBerly.showSourceCodeWindow(title, moduleSourceCode);
+                ErlyBerly.showPane(title, ErlyBerly.wrapInPane(new CodeView(moduleSourceCode)));
             }
         }
         else {
-            ErlyBerly.showSourceCodeWindow(title, moduleSourceCode);
+            ErlyBerly.showPane(title, ErlyBerly.wrapInPane(new CodeView(moduleSourceCode)));
         }
     }
 

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -208,14 +208,8 @@ public class ModFuncContextMenu extends ContextMenu {
 
     private void toggleTraceMod(Collection<ModFunc> functions){
        for (ModFunc func : functions) {
-           if(!isModuleInfo(func)){
-               dbgController.toggleTraceModFunc(func);
-           }
+           dbgController.toggleTraceModFunc(func);
        }
-    }
-
-    private boolean isModuleInfo(ModFunc func) {
-        return func.toString().equals("module_info/0") || func.toString().equals("module_info/1");
     }
     
    private void onModuleCode(ActionEvent ae){
@@ -301,7 +295,9 @@ public class ModFuncContextMenu extends ContextMenu {
         ArrayList<ModFunc> funs = new ArrayList<>();
         for (TreeItem<ModFunc> treeItem : filteredTreeModules) {
             for (TreeItem<ModFunc> modFunc : treeItem.getChildren()) {
-                funs.add(modFunc.getValue());
+                if(!modFunc.getValue().isModuleInfo()) {
+                    funs.add(modFunc.getValue());
+                }
             }
         }
         return funs;

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -1,5 +1,8 @@
 package erlyberly;
 
+import java.awt.Desktop;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -234,7 +237,7 @@ public class ModFuncContextMenu extends ContextMenu {
                 String functionName = mf.getFuncName();
                 Integer arity = mf.getArity();
                 modSrc = fetchModCode(menuItemClicked, moduleName, functionName, arity);
-                showModuleSourceCode(moduleName + ":" + functionName + "/" + arity.toString() + " Source code "+moduleName, modSrc);
+                showModuleSourceCode(moduleName, modSrc);
             } 
         } catch (Exception e) {
             throw new RuntimeException("failed to load the source code.", e);
@@ -264,7 +267,23 @@ public class ModFuncContextMenu extends ContextMenu {
     }
 
     private void showModuleSourceCode(String title, String moduleSourceCode) {
-        ErlyBerly.showSourceCodeWindow(title, moduleSourceCode);
+        Boolean showSourceInSystemEditor = PrefBind.getOrDefaultBoolean("showSourceInSystemEditor", false);
+        if(showSourceInSystemEditor) {
+            try {
+                File tmpSourceFile = File.createTempFile(title, ".erl");
+                FileOutputStream out = new FileOutputStream(tmpSourceFile);
+                out.write(moduleSourceCode.getBytes());
+                out.close();
+                Desktop.getDesktop().edit(tmpSourceFile);
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+                ErlyBerly.showSourceCodeWindow(title, moduleSourceCode);
+            }
+        }
+        else {
+            ErlyBerly.showSourceCodeWindow(title, moduleSourceCode);
+        }
     }
 
     /**

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -143,7 +143,7 @@ public class ModFuncContextMenu extends ContextMenu {
             OtpErlangObject callGraph = ErlyBerly.nodeAPI().callGraph(OtpUtil.atom(func.getModuleName()), OtpUtil.atom(func.getFuncName()), new OtpErlangLong(func.getArity()));
             CallGraphView callGraphView = new CallGraphView(dbgController);
             callGraphView.callGraph((OtpErlangTuple) callGraph);
-            ErlyBerly.showPane(func.toFullString() + " call graph", callGraphView);
+            ErlyBerly.showPane(func.toFullString() + " call graph", ErlyBerly.wrapInPane(callGraphView));
         } 
         catch (OtpErlangException | IOException e) {
             e.printStackTrace();

--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -31,7 +31,7 @@ public class PrefBind {
     private static File erlyberlyConfig;
     
     private static boolean awaitingStore;
-
+    
     public static void bind(final String propName, StringProperty stringProp) {
         if(props == null) {
             return;
@@ -56,7 +56,7 @@ public class PrefBind {
             }});
     }
     
-    public static void bind_boolean(final String propName, BooleanProperty boolProp){
+    public static void bindBoolean(final String propName, BooleanProperty boolProp){
         if(props == null) {
             return;
         }
@@ -83,7 +83,6 @@ public class PrefBind {
     
     static void store() {
         try {
-            System.out.println("Storing "+props);
             props.store(new FileOutputStream(erlyberlyConfig), " erlyberly at https://github.com/andytill/erlyberly");
         } catch (IOException e) {
             e.printStackTrace();
@@ -119,5 +118,9 @@ public class PrefBind {
 
     public static Object getOrDefault(String key, Object theDefault) {
         return props.getOrDefault(key, theDefault);
+    }
+    
+    public static boolean getOrDefaultBoolean(String key, boolean theDefault) {
+        return Boolean.parseBoolean(PrefBind.getOrDefault("showSourceInSystemEditor", false).toString());
     }
 }

--- a/src/main/java/erlyberly/PreferencesView.java
+++ b/src/main/java/erlyberly/PreferencesView.java
@@ -5,10 +5,8 @@ import java.util.ResourceBundle;
 
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.Button;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.TextField;
-import javafx.stage.Stage;
 
 public class PreferencesView implements Initializable {
     
@@ -17,39 +15,21 @@ public class PreferencesView implements Initializable {
     @FXML
     private TextField cookieField;
     @FXML
-    private Button saveButton;
-    @FXML
     private CheckBox autoConnectField;
+    @FXML
+    private CheckBox showSourceInSystemEditorBox;
     @FXML
     private CheckBox hideProcesses;
     @FXML
     private CheckBox hideModules;
-//  @FXML
-//  private TextField processPaneWidth;
-//  @FXML
-//  private TextField modulesPaneWidth;
     
     @Override
     public void initialize(URL url, ResourceBundle r) {
         PrefBind.bind("targetNodeName", nodeNameField.textProperty());
         PrefBind.bind("cookieName", cookieField.textProperty());
-        PrefBind.bind_boolean("autoConnect", autoConnectField.selectedProperty());
-        PrefBind.bind_boolean("hideProcesses", hideProcesses.selectedProperty());
-        PrefBind.bind_boolean("hideModules", hideModules.selectedProperty());
+        PrefBind.bindBoolean("autoConnect", autoConnectField.selectedProperty());
+        PrefBind.bindBoolean("hideProcesses", hideProcesses.selectedProperty());
+        PrefBind.bindBoolean("hideModules", hideModules.selectedProperty());
+        PrefBind.bindBoolean("showSourceInSystemEditor", showSourceInSystemEditorBox.selectedProperty());
     }
-    
-    @FXML
-    public void onSave(){
-        PrefBind.store();
-        closeThisWindow();
-    }
-    
-    // TODO: make into a more generic stage handling function.
-    private void closeThisWindow() {
-        Stage stage;    
-        stage = (Stage) saveButton.getScene().getWindow();
-        stage.close();
-    }
-
-    
 }

--- a/src/main/java/erlyberly/ProcView.java
+++ b/src/main/java/erlyberly/ProcView.java
@@ -195,7 +195,7 @@ public class ProcView implements Initializable {
         VBox.setVgrow(termTreeView, Priority.ALWAYS);
         termTreeView.populateFromTerm(obj); 
 
-        ErlyBerly.showPane("Process State for " + procInfo.getShortName(), termTreeView);
+        ErlyBerly.showPane("Process State for " + procInfo.getShortName(), ErlyBerly.wrapInPane(termTreeView));
     }
     
     @FXML
@@ -263,7 +263,7 @@ public class ProcView implements Initializable {
         PieChart pieChart;
         pieChart = new PieChart(data);
         pieChart.setTitle(title);
-        ErlyBerly.showPane(title, pieChart);
+        ErlyBerly.showPane(title, ErlyBerly.wrapInPane(pieChart));
     }
 
     private String procDescription(ProcInfo proc) {

--- a/src/main/java/erlyberly/SeqTraceView.java
+++ b/src/main/java/erlyberly/SeqTraceView.java
@@ -82,7 +82,7 @@ public class SeqTraceView extends VBox {
         argTermsTreeView = newTermTreeView();
         argTermsTreeView.populateFromTerm(seqTraceLog.getMessage());
         
-        ErlyBerly.showPane("Seq Trace", argTermsTreeView);
+        ErlyBerly.showPane("Seq Trace", ErlyBerly.wrapInPane(argTermsTreeView));
     }
 
     private TermTreeView newTermTreeView() {

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -16,6 +16,7 @@ import javafx.scene.control.TreeView;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.VBox;
 
 @SuppressWarnings("rawtypes")
 public class TermTreeView extends TreeView<TermTreeItem> {
@@ -44,7 +45,7 @@ public class TermTreeView extends TreeView<TermTreeItem> {
             HexstarView hexstarView;
             hexstarView = new HexstarView();
             hexstarView.setBinary(binary);
-            ErlyBerly.showPane("Hex View", hexstarView);
+            ErlyBerly.showPane("Hex View", new VBox(hexstarView));
         }
     }
 
@@ -63,7 +64,7 @@ public class TermTreeView extends TreeView<TermTreeItem> {
             OtpErlangList props = ErlyBerly.nodeAPI().dictToPropslist(dict);
             TermTreeView parentControl = new TermTreeView();
             parentControl.populateFromTerm(props);
-            ErlyBerly.showPane("dict_to_list", parentControl);
+            ErlyBerly.showPane("dict_to_list", ErlyBerly.wrapInPane(parentControl));
         }
         catch (Exception e1) {
             e1.printStackTrace();

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -139,7 +139,7 @@ public class TopBarView implements Initializable {
                         menuItem.setGraphic(new CrashReportGraphic(crashReport));
                         menuItem.setOnAction((action) -> { 
                             unreadCrashReportsProperty.set(0);
-                            ErlyBerly.showPane("Crash Report", crashReportView(crashReport));
+                            ErlyBerly.showPane("Crash Report", ErlyBerly.wrapInPane(crashReportView(crashReport)));
                         });
                         crashReportsButton.getItems().add(menuItem);
                         }
@@ -331,7 +331,7 @@ public class TopBarView implements Initializable {
         
         pieChart = new PieChart(data);
         pieChart.setTitle(title);
-        ErlyBerly.showPane(title, pieChart);
+        ErlyBerly.showPane(title, ErlyBerly.wrapInPane(pieChart));
     }
 
     /**

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -185,7 +185,7 @@ public class TopBarView implements Initializable {
         prefButton.setGraphicTextGap(0d);
         prefButton.setTooltip(new Tooltip("Preferences"));
         prefButton.disableProperty().bind(ErlyBerly.nodeAPI().connectedProperty().not());
-        prefButton.setOnAction((e) -> { showPreferences(); });
+        prefButton.setOnAction((e) -> { displayPreferencesPane(); });
         
         hideProcsProperty().addListener((Observable o) -> { toggleHideProcs(); });
         hideFunctionsProperty().addListener((Observable o) -> { toggleHideFuncs(); });
@@ -200,8 +200,8 @@ public class TopBarView implements Initializable {
         topBox.getItems().addAll(rhsSpacer(), tweetButton);
         
         // let's store the ui preferences, as the end user changes them...
-        PrefBind.bind_boolean("hideProcesses", hideProcessesButton.selectedProperty());
-        PrefBind.bind_boolean("hideModules", hideFunctionsButton.selectedProperty());
+        PrefBind.bindBoolean("hideProcesses", hideProcessesButton.selectedProperty());
+        PrefBind.bindBoolean("hideModules", hideFunctionsButton.selectedProperty());
         
         boolean hideProcs = PrefBind.getOrDefault("hideProcesses", "false").equals("true");
         boolean hideMods = PrefBind.getOrDefault("hideModules", "false").equals("true");
@@ -436,11 +436,6 @@ public class TopBarView implements Initializable {
         displayConnectionPopup(s);
     }
     
-    public void showPreferences(){
-        Stage s = new Stage();
-        displayPreferencesPopup(s);
-    }
-    
     // TODO: (improve) lazy copy paste 
     // TODO: THIS was a ugly copy paste effort
     private void displayConnectionPopup(Stage primaryStage) {
@@ -470,35 +465,12 @@ public class TopBarView implements Initializable {
 
         connectStage.show();
     }
-    
-    // TODO: (improve) lazy copy paste 
-    // TODO: THIS was a ugly copy paste effort
-    private void displayPreferencesPopup(Stage stage){
-        Stage prefStage;
-        
-        prefStage = new Stage();
-        prefStage.initModality(Modality.WINDOW_MODAL);
-        prefStage.setScene(new Scene(new FxmlLoadable("/erlyberly/preferences.fxml").load()));
-        prefStage.setAlwaysOnTop(true);
-        
-        // javafx vertical resizing is laughably ugly, lets just disallow it
-        prefStage.setResizable(false);
-        prefStage.setWidth(400);
-        
-        // if the user closes the window without connecting then close the app
-        prefStage.setOnCloseRequest(new EventHandler<WindowEvent>() {
-            @Override
-            public void handle(WindowEvent e) {
-                if(!ErlyBerly.nodeAPI().connectedProperty().get()) {
-                    // save the preferences
-                }
-                
-                Platform.runLater(() -> { 
-                    //primaryStage.setResizable(true);
-                });
-            }});
 
-        prefStage.show();
+    private void displayPreferencesPane() {
+        ErlyBerly.showPane(
+            "Preferences",
+            ErlyBerly.wrapInPane(new FxmlLoadable("/erlyberly/preferences.fxml").load())
+        );
     }
     
     class ErlangMemoryThread extends Thread {

--- a/src/main/java/ui/TabPaneDetacher.java
+++ b/src/main/java/ui/TabPaneDetacher.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.Cursor;
@@ -131,6 +132,13 @@ public class TabPaneDetacher {
         }
         tabPane.getTabs().stream().forEach(t -> {
             t.setClosable(false);
+        });
+        tabPane.getTabs().addListener((Observable o) -> {
+            for (Tab tabX : tabPane.getTabs()) {
+                if(!(tabX.getContent() instanceof Pane)) {
+                    throw new RuntimeException("Tab added where the content node was not a subclass of Pane, this means it cannot be dragged by TabPaneDetacher.");
+                }
+            }
         });
         tabPane.setOnDragDetected(
                 (MouseEvent event) -> {


### PR DESCRIPTION
Set the tab title for trace term view to the pid and module:function/arity.
Some tabs could not be dragged into new windows because they were not subclasses of Pane, so wrap all tab content in a Pane.
Added a preference option for open source code in the system text editor.
Made preferences and source code windows open in tabs instead.
Removed a print line #72
Do not trace module_info when Trace All is invoked from the menu.  #67