### PR TITLE
Show modules as they are loaded

### DIFF
--- a/src/main/java/erlyberly/ConnectionView.java
+++ b/src/main/java/erlyberly/ConnectionView.java
@@ -120,7 +120,7 @@ public class ConnectionView implements Initializable {
                 ErlyBerly
                     .nodeAPI()
                     .connectionInfo(remoteNodeName, cookie)
-                    .manual_connect();
+                    .manualConnect();
 
                 Platform.runLater(() -> { closeThisWindow(); });
             }

--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -14,6 +14,7 @@ import javafx.fxml.Initializable;
 
 import com.ericsson.otp.erlang.OtpErlangException;
 import com.ericsson.otp.erlang.OtpErlangList;
+import com.ericsson.otp.erlang.OtpErlangTuple;
 
 import erlyberly.node.NodeAPI;
 import erlyberly.node.NodeAPI.RpcCallback;
@@ -228,6 +229,10 @@ public class DbgController implements Initializable {
     public String moduleFunctionAbstCode(String module, String function, Integer arity) throws IOException, OtpErlangException {
         String moduleCode = ErlyBerly.nodeAPI().moduleFunctionAbstCode(module, function, arity);
         return moduleCode;
+    }
+
+    public void setModuleLoadedCallback(RpcCallback<OtpErlangTuple> moduleLoadedCallback) {
+        ErlyBerly.nodeAPI().setModuleLoadedCallback(moduleLoadedCallback);
     }
     
 }


### PR DESCRIPTION
Push notifications of module loads to the erlyberly UI so it can update the interface automatically. This means the user does not have to reload modules all the time.

Now when erlyberly loads it will start dbg straight away to put traces onto the code module to listen for modules being loaded. Previously it would only start it when the first trace was applied.

Modules can also be loaded form the code paths at start up so they are shown in the modules tree ready for tracing. All the code paths known to the node are filtered using the regular expression in the `loadModulesRegex` property in the `.erlyberly` configuration file.  The beam files in the matched apps ebin directory are loaded if they are not already.

For example.

    loadModulesRegex=.*riak.*

This will load all beams where the app file path has riak in it.

Fixes #46