### PR TITLE
Show stack traces for function traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,4 +211,4 @@ The following people have contributed code to erlyberly:
 + [@ruanpienaar](https://github.com/ruanpienaar)
 + [@horvand ](https://github.com/horvand)
 
-The hex editor originated from [hexstar](https://github.com/Velocity-/Hexstar).
+The hex editor originated from [hexstar](https://github.com/Velocity-/Hexstar). The stack trace parsing is taken from [redbug](https://github.com/massemanet/eper). Tab pane drag to window is from [shichimifx](https://bitbucket.org/Jerady/shichimifx).

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -31,6 +31,7 @@ import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
 import javafx.css.PseudoClass;
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.control.Control;
@@ -40,6 +41,7 @@ import javafx.scene.control.SplitPane;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
+import javafx.scene.control.TitledPane;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
@@ -243,19 +245,28 @@ public class DbgTraceView extends VBox {
         argTermsTreeView = newTermTreeView();
         argTermsTreeView.populateFromListContents((OtpErlangList)args);
 
-        SplitPane splitPane;
+        SplitPane splitPane, splitPaneH;
 
         splitPane = new SplitPane();
+        splitPane.setOrientation(Orientation.HORIZONTAL);
         splitPane.getItems().addAll(
             labelledTreeView("Function arguments", argTermsTreeView),
             labelledTreeView("Result", resultTermsTreeView)
         );
 
+        StackTraceView stackTraceView;
+        stackTraceView = new StackTraceView();
+        stackTraceView.populateFromMfaList(traceLog.getStackTrace());
+        TitledPane titledPane = new TitledPane("Stack Trace", stackTraceView);
+        splitPaneH = new SplitPane();
+        splitPaneH.setOrientation(Orientation.VERTICAL);
+        splitPaneH.getItems().addAll(splitPane, titledPane);
+
         StringBuilder sb = new StringBuilder(traceLog.getPidString());
         sb.append(" ");
         traceLog.appendModFuncArity(sb);
 
-        ErlyBerly.showPane(sb.toString(), ErlyBerly.wrapInPane(splitPane));
+        ErlyBerly.showPane(sb.toString(), ErlyBerly.wrapInPane(splitPaneH));
     }
 
     private Node labelledTreeView(String label, TermTreeView node) {

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -257,7 +257,8 @@ public class DbgTraceView extends VBox {
         StackTraceView stackTraceView;
         stackTraceView = new StackTraceView();
         stackTraceView.populateFromMfaList(traceLog.getStackTrace());
-        TitledPane titledPane = new TitledPane("Stack Trace", stackTraceView);
+        String stackTraceTitle = "Stack Trace (" + traceLog.getStackTrace().arity() + ")";
+        TitledPane titledPane = new TitledPane(stackTraceTitle, stackTraceView);
         splitPaneH = new SplitPane();
         splitPaneH.setOrientation(Orientation.VERTICAL);
         splitPaneH.getItems().addAll(splitPane, titledPane);

--- a/src/main/java/erlyberly/ModFunc.java
+++ b/src/main/java/erlyberly/ModFunc.java
@@ -35,8 +35,8 @@ public class ModFunc implements Comparable<ModFunc> {
     private final boolean synthetic;
 
     public ModFunc(String moduleName, String funcName, int arity, boolean exported, boolean synthetic) {
-        this.moduleName = moduleName;
-        this.funcName = funcName;
+        this.moduleName = (moduleName != null) ? moduleName.replace("'", "") : null;
+        this.funcName = (funcName != null) ? funcName.replace("'", "") : null;
         this.arity = arity;
         this.exported = exported;
         this.synthetic = synthetic;

--- a/src/main/java/erlyberly/StackTraceView.java
+++ b/src/main/java/erlyberly/StackTraceView.java
@@ -1,0 +1,142 @@
+/**
+ * erlyberly, erlang trace debugger
+ * Copyright (C) 2016 Andy Till
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package erlyberly;
+
+import com.ericsson.otp.erlang.OtpErlangAtom;
+import com.ericsson.otp.erlang.OtpErlangList;
+import com.ericsson.otp.erlang.OtpErlangLong;
+import com.ericsson.otp.erlang.OtpErlangObject;
+import com.ericsson.otp.erlang.OtpErlangRangeException;
+import com.ericsson.otp.erlang.OtpErlangTuple;
+
+import erlyberly.StackTraceView.ErlyberlyStackTraceElement;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.util.Callback;
+
+public class StackTraceView extends ListView<ErlyberlyStackTraceElement> {
+
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public StackTraceView() {
+        applyStackTraceCellFactory((ListView)this);
+    }
+
+    private void applyStackTraceCellFactory(ListView<ErlyberlyStackTraceElement> listview) {
+        listview.setCellFactory(new Callback<ListView<ErlyberlyStackTraceElement>, ListCell<ErlyberlyStackTraceElement>>() {
+            @Override
+            public ListCell<ErlyberlyStackTraceElement> call(ListView<ErlyberlyStackTraceElement> param) {
+                return new ListCell<ErlyberlyStackTraceElement>() {
+                    private final Hyperlink functionLink = new Hyperlink();
+                    {
+                        setGraphic(functionLink);
+                        functionLink.setOnAction((e) -> {
+                            ErlyberlyStackTraceElement stackElement = getItem();
+                            if(stackElement == null)
+                                return;
+                            ModFunc mf = stackElement.getModFunc();
+                            try {
+                                String source = ErlyBerly.nodeAPI().moduleFunctionSourceCode(
+                                        mf.getModuleName(), mf.getFuncName(), mf.getArity());
+                                ErlyBerly.showPane(
+                                    "Crash Report Stack",
+                                    ErlyBerly.wrapInPane(new CodeView(source))
+                                );
+                            } catch (Exception e1) {
+                                e1.printStackTrace();
+                            }
+                        });
+                    }
+
+                    @Override
+                    public void updateItem(ErlyberlyStackTraceElement item, boolean empty) {
+                        super.updateItem(item, empty);
+                        if(item == null)
+                            functionLink.setText("");
+                        else
+                            functionLink.setText(item.toString());
+                    }
+                };
+            }
+        });
+    }
+
+    public void populateFromCrashReport(CrashReport crashReport) {
+        try {
+            getItems().addAll(crashReport.<ErlyberlyStackTraceElement>mapStackTraces((module, function, arity, file, line) -> {
+                try {
+                    ModFunc modFunc = mfaToModFunc(module, function, arity);
+                    return new ErlyberlyStackTraceElement(modFunc, file.toString(), line.longValue());
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private ModFunc mfaToModFunc(OtpErlangAtom module, OtpErlangAtom function, OtpErlangLong arity) {
+        boolean exported = false;
+        boolean synthetic = false;
+        try {
+            return new ModFunc(module.toString(), function.toString(), arity.intValue(), exported, synthetic);
+        }
+        catch (OtpErlangRangeException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void populateFromMfaList(OtpErlangList stackTrace) {
+        for (OtpErlangObject obj : stackTrace) {
+            OtpErlangTuple tuple = (OtpErlangTuple) obj;
+            OtpErlangAtom module = (OtpErlangAtom) tuple.elementAt(0);
+            OtpErlangAtom function = (OtpErlangAtom) tuple.elementAt(1);
+            OtpErlangLong arity = (OtpErlangLong) tuple.elementAt(2);
+            ModFunc modFunc = mfaToModFunc(module, function, arity);
+            getItems().add(new ErlyberlyStackTraceElement(modFunc , "", 0L));
+        }
+    }
+
+    /**
+     * Put erlyberly on the front of this because there is already a StaceTraceElement
+     * class in the standard library.
+     */
+    static class ErlyberlyStackTraceElement {
+        private final ModFunc modFunc;
+        private final long line;
+        private final String file;
+
+        public ErlyberlyStackTraceElement(ModFunc modFunc, String file, long line) {
+            this.modFunc = modFunc;
+            this.file = file;
+            this.line = line;
+        }
+
+        public ModFunc getModFunc() {
+            return modFunc;
+        }
+
+        @Override
+        public String toString() {
+            return modFunc.toFullString() + "  (" + file + ":" + line +")";
+        }
+    }
+}

--- a/src/main/java/erlyberly/StackTraceView.java
+++ b/src/main/java/erlyberly/StackTraceView.java
@@ -31,8 +31,6 @@ import javafx.scene.control.ListView;
 import javafx.util.Callback;
 
 public class StackTraceView extends ListView<ErlyberlyStackTraceElement> {
-
-
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public StackTraceView() {
         applyStackTraceCellFactory((ListView)this);
@@ -113,6 +111,10 @@ public class StackTraceView extends ListView<ErlyberlyStackTraceElement> {
             ModFunc modFunc = mfaToModFunc(module, function, arity);
             getItems().add(new ErlyberlyStackTraceElement(modFunc , "", 0L));
         }
+    }
+
+    public boolean isStackTracesEmpty() {
+        return getItems().isEmpty();
     }
 
     /**

--- a/src/main/java/erlyberly/StackTraceView.java
+++ b/src/main/java/erlyberly/StackTraceView.java
@@ -136,7 +136,11 @@ public class StackTraceView extends ListView<ErlyberlyStackTraceElement> {
 
         @Override
         public String toString() {
-            return modFunc.toFullString() + "  (" + file + ":" + line +")";
+            String display = modFunc.toFullString();
+            if(file != null && !file.isEmpty()) {
+                display += "  (" + file + ":" + line +")";
+            }
+            return display;
         }
     }
 }

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -302,4 +302,11 @@ public class TraceLog implements Comparable<TraceLog> {
     public static TraceLog newNodeDown() {
         return new TraceLog("breaker-row", "NODE DOWN");
     }
+
+    public OtpErlangList getStackTrace() {
+        OtpErlangList stacktrace = (OtpErlangList) map.get(OtpUtil.atom("stack_trace"));
+        if(stacktrace == null)
+            stacktrace = new OtpErlangList();
+        return stacktrace;
+    }
 }

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -71,7 +71,6 @@ public class TraceLog implements Comparable<TraceLog> {
         registeredName = regNameString().intern();
         function =  appendModFuncArity(new StringBuilder()).toString().intern();
         argsString = appendArgsToString(new StringBuilder(), getArgsList().elements()).toString();
-        System.out.println("STACK TRACE: " + map.get(OtpUtil.atom("stack_trace")));
         cssClass = null;
     }
 

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -71,7 +71,7 @@ public class TraceLog implements Comparable<TraceLog> {
         registeredName = regNameString().intern();
         function =  appendModFuncArity(new StringBuilder()).toString().intern();
         argsString = appendArgsToString(new StringBuilder(), getArgsList().elements()).toString();
-
+        System.out.println("STACK TRACE: " + map.get(OtpUtil.atom("stack_trace")));
         cssClass = null;
     }
 

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -104,9 +104,9 @@ public class ErlangFormatter implements TermFormatter {
     @Override
     public String modFuncArgsToString(OtpErlangTuple mfa) {
         StringBuilder sb = new StringBuilder();
-        sb.append(mfa.elementAt(0))
+        sb.append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(0)))
           .append(":")
-          .append(mfa.elementAt(1))
+          .append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(1)))
           .append("(");
         OtpErlangList args = (OtpErlangList) mfa.elementAt(2);
         ArrayList<String> stringArgs = new ArrayList<>();
@@ -116,6 +116,10 @@ public class ErlangFormatter implements TermFormatter {
         sb.append(String.join(", ", stringArgs));
         sb.append(")");
         return sb.toString();
+    }
+
+    private String atomToStringNoQuotes(OtpErlangAtom atom) {
+        return atom.atomValue();
     }
 
     @Override

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -673,7 +673,7 @@ code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
 
 stak(Bin) ->
-  lists:foldl(fun munge/2,[],string:tokens(binary_to_list(Bin),"\n")).
+  lists:foldr(fun munge/2,[],string:tokens(binary_to_list(Bin),"\n")).
 
 munge(I,Out) ->
   case lists:reverse(I) of

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -700,9 +700,12 @@ mfaf(I) ->
 stack_to_mfa(String) ->
     case string:tokens(String, ":/") of
         [Mod, Func, Arity] ->
-            {list_to_existing_atom(Mod),
-             list_to_existing_atom(Func),
-             list_to_integer(string:strip(Arity))};
+            {list_to_existing_atom(fix_elixir_strings(Mod)),
+             list_to_existing_atom(fix_elixir_strings(Func)),
+             list_to_integer(string:strip(fix_elixir_strings(Arity)))};
         _ ->
             String
     end.
+
+fix_elixir_strings(String) ->
+    re:replace(String, "\"|\'", "", [global, {return, list}]).

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -689,7 +689,7 @@ munge(I,Out) ->
     _ ->
       case string:str(I, "Return addr") of
         0 ->
-          case string:str(I, "cp = ") of
+          case string:str(I, "CP:") of
             0 -> Out;
             _ -> [mfaf(I)|Out]
           end;

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -666,11 +666,19 @@ terminate(_Reason, _State) -> ok.
 
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 
-
-%%% ============================================================================
-%%% redbug process_dump call stack parsing
-%%% ============================================================================
-
+%%% https://github.com/massemanet/eper/blob/f7a1b4504f5eefc61fb9da7101fdaccc687021cd/src/redbug.erl
+%%%
+%%% Copyright (c) 2008-2013 mats cronqvist
+%%% 
+%%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%%% of this software and associated documentation files (the "Software"), to deal
+%%% in the Software without restriction, including without limitation the rights
+%%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%%% copies of the Software, and to permit persons to whom the Software is
+%%% furnished to do so, subject to the following conditions:
+%%% 
+%%% The above copyright notice and this permission notice shall be included in
+%%% all copies or substantial portions of the Software.
 
 stak(Bin) ->
   lists:foldr(fun munge/2,[],string:tokens(binary_to_list(Bin),"\n")).

--- a/src/main/resources/erlyberly/erlyberly.css
+++ b/src/main/resources/erlyberly/erlyberly.css
@@ -3,6 +3,10 @@
     src: url('/erlyberly/SourceCodePro-Medium.ttf');
 }
 
+/*
+ * mono space font classes
+ */
+
 .erlyberly-code {
     -fx-font-family: "Source Code Pro";
 }
@@ -25,6 +29,13 @@
     -fx-font-family: "Source Code Pro";
 }
 
+.hyperlink:selected{
+   -fx-text-fill: white;
+}
+
+.list-cell:selected > .hyperlink {
+    -fx-text-fill: white;
+}
 /*
  * a break row, to show a change of state between traces.
  */


### PR DESCRIPTION
Show the stack trace for function traces, to show were a function was called.

<img width="1448" alt="screen shot 2016-04-30 at 10 55 43" src="https://cloud.githubusercontent.com/assets/213455/14935235/2089ff5c-0ec2-11e6-9ac9-116093f5912f.png">

- [ ] Make this optional using preferences. The `process_dump` option in the match spec will print the process dictionary to a binary which could be large for some applications, and cause performance problems.
- [x] How to display the stack trace for a function call? I'm thinking showing it as part of the term tree when the trace is double clicked.  Adding a horizontal split pane that could be minimised.
- [x] There seems to be some missing stack traces in some of the tests I did, need to investigate if `process_dump` is returning these or they are not being parsed correctly, or erlyberly is losing them for some reason.

1. **Update:** in the redbug documentation, it specifies that functions may be removed from the stack trace because of tail call optimisations.
2. @aboroska has a reproducible test where **sometimes** functions are removed and other times not https://github.com/andytill/erlyberly/pull/98#issuecomment-211596062.

**Update:** took the `case string:str(I, "CP: ")` change @aboroska recommended and `Test1` was appearing in the stack trace.

- [x] A stack trace is not shown for elixir functions.