### PR TITLE
Fix stack trace window for Elixir

### DIFF
--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -700,9 +700,12 @@ mfaf(I) ->
 stack_to_mfa(String) ->
     case string:tokens(String, ":/") of
         [Mod, Func, Arity] ->
-            {list_to_existing_atom(Mod),
-             list_to_existing_atom(Func),
-             list_to_integer(string:strip(Arity))};
+            {list_to_existing_atom(fix_elixir_strings(Mod)),
+             list_to_existing_atom(fix_elixir_strings(Func)),
+             list_to_integer(string:strip(fix_elixir_strings(Arity)))};
         _ ->
             String
     end.
+
+fix_elixir_strings(String) ->
+    re:replace(String, "\"|\'", "", [global, {return, list}]).


### PR DESCRIPTION
Elixir denotes single and double quotes differently from Erlang.

Single quotes are the normal char lists. Double quotes are binary
strings. This causes confusion when the binary stack trace is
stringified the Erlang way on an Elixir vm. We need to strip all the
quotes.