### PR TITLE
Fix for NPEs and ClassCastExceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,16 @@ If you are using `io:format/2` or lager for debugging then erlyberly can save yo
 
 ### Quick start
 
-A one liner to go from zero to erlyberly user.  You will need **JDK 8u20** or higher installed to run erlyberly, download it [here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
+A one liner to go from zero to erlyberly user.  You will need erlc (erlang compiler) on the path and **JDK 8u20** or higher installed to run erlyberly, download it [here](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
 
 ```
 git clone git@github.com:andytill/erlyberly.git && cd erlyberly && ./mvnw clean compile install assembly:single && java -jar target/*runnable.jar
+```
+
+If you already have erlyberly and want to update to have the latest features, run the following from the erlyberly project directory.
+
+```
+git pull origin && ./mvnw clean compile install assembly:single && java -jar target/*runnable.jar
 ```
 
 ### Compiling

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -199,6 +199,10 @@ public class ModFuncContextMenu extends ContextMenu {
 
         if(selectedItem == null)
             return;
+        if(selectedItem.getValue() == null)
+            return;
+        if(!selectedItem.getValue().isModule())
+            selectedItem = selectedItem.getParent();
 
         // get all the functions we may trace
         HashSet<ModFunc> funcs = new HashSet<ModFunc>();

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -133,7 +133,7 @@ public class TraceLog implements Comparable<TraceLog> {
     private StringBuilder toCallString(StringBuilder sb, boolean appendArity) {
         OtpErlangAtom regName = (OtpErlangAtom) map.get(ATOM_REG_NAME);
 
-        if(!ATOM_UNDEFINED.equals(regName)) {
+        if(regName != null && !ATOM_UNDEFINED.equals(regName)) {
             sb.append(regName.atomValue());
         }
         else {

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -121,7 +121,7 @@ public class ErlangFormatter implements TermFormatter {
     @Override
     public String modFuncArityToString(OtpErlangTuple mfa) {
         StringBuilder sb = new StringBuilder();
-        OtpErlangList argsList = (OtpErlangList) mfa.elementAt(2);
+        OtpErlangList argsList = OtpUtil.toErlangList(mfa.elementAt(2));
         sb.append(mfa.elementAt(0))
           .append(":")
           .append(mfa.elementAt(1))

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -242,4 +242,23 @@ public class OtpUtil {
         }
         return true;
     }
+
+    /**
+     * jinterface interprets lists of integers OtpErlangString whatever
+     * might be the intent, for example a list of function arguments `[10]`.
+     *
+     * This can cause ClassCastExceptions when something that is normally an
+     * OtpErlangList comes back as an OtpErlangString, which does not inherit
+     * from OtpErlangList!
+     */
+    public static OtpErlangList toErlangList(OtpErlangObject obj) {
+        if(obj instanceof OtpErlangString) {
+            return new OtpErlangList(((OtpErlangString)obj).stringValue());
+        }
+        else {
+            // we have done our best to convert the nobbly string objects to
+            // lists, if it fails just throw a ClassCastException
+            return (OtpErlangList)obj;
+        }
+    }
 }


### PR DESCRIPTION
Fix for the `ClassCastException` that was noticed here: https://github.com/andytill/erlyberly/pull/98#issuecomment-211596062

This was happening because of lists of function arguments get interpreted by jinterface as type OtpErlangString if the elements are integers.