### PR TITLE
Decompile funs to erlang source plus misc fixes 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
                   <exclude>**/checkstyle.xml</exclude>
                   <exclude>**/README</exclude>
                   <exclude>**/mvnw</exclude>
-                  <exclude>**/.checkstule</exclude>
+                  <exclude>**/.checkstyle</exclude>
                   <exclude>**/.mvn/**</exclude>
                   <exclude>src/etc/**</exclude>
                   <exclude>src/test/resources/**</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -69,13 +69,16 @@
               </properties>
               <excludes>
                   <exclude>**/pom.xml</exclude>
+                  <exclude>**/LICENSE</exclude>
                   <exclude>**/checkstyle.xml</exclude>
                   <exclude>**/README</exclude>
                   <exclude>**/mvnw</exclude>
+                  <exclude>**/.checkstule</exclude>
                   <exclude>**/.mvn/**</exclude>
                   <exclude>src/etc/**</exclude>
                   <exclude>src/test/resources/**</exclude>
                   <exclude>src/main/resources/**</exclude>
+                  <exclude>**/src/main/java/hexstar/HexstarView.java</exclude>
               </excludes>
           </configuration>
       </plugin>

--- a/src/main/java/erlyberly/CodeView.java
+++ b/src/main/java/erlyberly/CodeView.java
@@ -22,7 +22,7 @@ import javafx.scene.control.TextArea;
 public class CodeView extends TextArea {
 
     {
-        getStyleClass().add("mod-src");
+        getStyleClass().add("erlyberly-code");
         setEditable(false);
     }
 

--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -114,19 +114,6 @@ public class DbgController implements Initializable {
         }
     }
 
-    // TODO:
-
-    public void removeTraces() {
-        ArrayList<ModFunc> tracesCopy = new ArrayList<ModFunc>(traces);
-
-        for (ModFunc function : tracesCopy) {
-            // TODO: simply remove the GUI trace selection...
-            // The back-end will be dealt with :)
-            //ErlyBerly.nodeAPI().stopTrace(function);
-            traces.remove(function);
-        }
-    }
-
     public void addTraceListener(InvalidationListener listener) {
         traces.addListener(listener);
     }

--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -44,17 +44,13 @@ public class DbgController implements Initializable {
 
     private final ObservableList<SeqTraceLog> seqTraces = FXCollections.observableArrayList();
 
-    private volatile boolean collectingTraces;
-
     private volatile boolean collectingSeqTraces;
-
-    public void setCollectingTraces(boolean collecting) {
-        collectingTraces = collecting;
-    }
 
     @Override
     public void initialize(URL url, ResourceBundle r) {
-        new TraceCollectorThread().start();
+        ErlyBerly.nodeAPI().setTraceLogCallback((traceLog) -> {
+            traceLogs.add(traceLog);
+        });
         new SeqTraceCollectorThread((seqs) -> { seqTraces.addAll(seqs); }).start();
     }
 
@@ -82,9 +78,8 @@ public class DbgController implements Initializable {
             ErlyBerly.nodeAPI().startTrace(function);
 
             traces.add(function);
-
-            setCollectingTraces(true);
-        } catch (Exception ex) {
+        }
+        catch (Exception ex) {
             ex.printStackTrace();
         }
     }
@@ -129,34 +124,6 @@ public class DbgController implements Initializable {
         }
         catch (OtpErlangException | IOException e) {
             e.printStackTrace();
-        }
-    }
-
-    class TraceCollectorThread extends Thread {
-        public TraceCollectorThread() {
-            setDaemon(true);
-            setName("Erlyberly Collect Traces");
-        }
-
-        @Override
-        public void run() {
-            while (true) {
-                if(collectingTraces && ErlyBerly.nodeAPI().isConnected()) {
-                    try {
-                        final ArrayList<TraceLog> collectTraceLogs = ErlyBerly.nodeAPI().collectTraceLogs();
-
-                        Platform.runLater(() -> { traceLogs.addAll(collectTraceLogs); });
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }
         }
     }
 

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -119,12 +119,12 @@ public class ErlyBerly extends Application {
             PrefBind.set("windowHeight", nv.toString());
         });
 
-        primaryStage.show();
 
         applyCssToWIndow(scene);
         primaryStage.setScene(scene);
         primaryStage.titleProperty().bind(NODE_API.summaryProperty());
         primaryStage.setResizable(true);
+        primaryStage.show();
 
         displayConnectionPopup(primaryStage);
 

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -105,13 +105,26 @@ public class ErlyBerly extends Application {
                 }
             }
         });
-        applyCssToWIndow(scene);
 
+        // the window size needs to be set before the scene is added or else it
+        // counts as a window resize and that also resizes the split panes
+        final double windowWidth = PrefBind.getOrDefaultDouble("windowWidth", 800D);
+        primaryStage.setWidth(windowWidth);
+        primaryStage.widthProperty().addListener((o, ov, nv) -> {
+            PrefBind.set("windowWidth", nv.toString());
+        });
+        final double windowHeight = PrefBind.getOrDefaultDouble("windowHeight", 600D);
+        primaryStage.setHeight(windowHeight);
+        primaryStage.heightProperty().addListener((o, ov, nv) -> {
+            PrefBind.set("windowHeight", nv.toString());
+        });
+
+        primaryStage.show();
+
+        applyCssToWIndow(scene);
         primaryStage.setScene(scene);
         primaryStage.titleProperty().bind(NODE_API.summaryProperty());
-        primaryStage.sizeToScene();
         primaryStage.setResizable(true);
-        primaryStage.show();
 
         displayConnectionPopup(primaryStage);
 
@@ -129,7 +142,11 @@ public class ErlyBerly extends Application {
                 System.exit(0);
             }
         });
-        dbgView.sizeSplitPanes();
+        // run this later because it requires the control's scene to be set, which
+        // may not have happened yet.
+        Platform.runLater(() -> {
+            dbgView.sizeSplitPanes();
+        });
     }
 
     public static void applyCssToWIndow(Scene scene) {

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -17,8 +17,12 @@
  */
 package erlyberly;
 
+import java.io.IOException;
+
 import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangBinary;
+import com.ericsson.otp.erlang.OtpErlangException;
+import com.ericsson.otp.erlang.OtpErlangFun;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangTuple;
@@ -53,11 +57,13 @@ public class TermTreeView extends TreeView<TermTreeItem> {
         MenuItem dictMenuItem = new MenuItem("Dict to List");
         dictMenuItem.setOnAction(this::onViewDict);
 
-
         MenuItem hexViewMenuItem = new MenuItem("Hex View");
         hexViewMenuItem.setOnAction(this::onHexView);
 
-        setContextMenu(new ContextMenu(copyMenuItem, dictMenuItem, hexViewMenuItem));
+        MenuItem decompileFunContextMenu = new MenuItem("Decompile Fun");
+        decompileFunContextMenu.setOnAction(this::onDecompileFun);
+
+        setContextMenu(new ContextMenu(copyMenuItem, dictMenuItem, decompileFunContextMenu, hexViewMenuItem));
     }
 
     public void onHexView(ActionEvent e) {
@@ -68,6 +74,21 @@ public class TermTreeView extends TreeView<TermTreeItem> {
             hexstarView = new HexstarView();
             hexstarView.setBinary(binary);
             ErlyBerly.showPane("Hex View", ErlyBerly.wrapInPane(hexstarView));
+        }
+    }
+
+    public void onDecompileFun(ActionEvent e) {
+        TreeItem<TermTreeItem> item = getSelectionModel().getSelectedItem();
+        if(item != null && item.getValue().getObject() instanceof OtpErlangFun) {
+            OtpErlangFun fun = (OtpErlangFun)item.getValue().getObject();
+            try {
+                String funSource = ErlyBerly.nodeAPI().decompileFun(fun);
+                ErlyBerly.showPane(fun + " Source Code", ErlyBerly.wrapInPane(new CodeView(funSource)));
+            } catch (OtpErlangException e1) {
+                e1.printStackTrace();
+            } catch (IOException e1) {
+                e1.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -232,9 +232,14 @@ public class TermTreeView extends TreeView<TermTreeItem> {
 
     private void onCopyCalls(ActionEvent e) {
         StringBuilder sbuilder = new StringBuilder();
+        for (TreeItem item : getSelectionModel().getSelectedItems()) {
+            copyTerms(item, sbuilder);
+        }
+    }
 
-        for (TreeItem obj : getSelectionModel().getSelectedItems()) {
-            sbuilder.append(obj.getValue()).append("\n");
+    private void copyTerms(TreeItem item, StringBuilder sbuilder) {
+        for (Object obj : item.getChildren()) {
+            copyTerms((TreeItem) obj, sbuilder);
         }
         copyToClipboard(sbuilder);
     }

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -138,7 +138,10 @@ public class TraceLog implements Comparable<TraceLog> {
         }
         else {
             OtpErlangString pidString = (OtpErlangString) map.get(ATOM_PID);
-            sb.append(pidString.stringValue());
+            if(pidString == null)
+                sb.append("<NULL PID>");
+            else
+                sb.append(pidString.stringValue());
         }
         sb.append(" ");
 

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -39,6 +39,7 @@ import com.ericsson.otp.erlang.OtpErlangBinary;
 import com.ericsson.otp.erlang.OtpErlangDecodeException;
 import com.ericsson.otp.erlang.OtpErlangException;
 import com.ericsson.otp.erlang.OtpErlangExit;
+import com.ericsson.otp.erlang.OtpErlangFun;
 import com.ericsson.otp.erlang.OtpErlangInt;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangLong;
@@ -675,5 +676,11 @@ public class NodeAPI {
      */
     public void setModuleLoadedCallback(RpcCallback<OtpErlangTuple> aModuleLoadedCallback) {
         moduleLoadedCallback = aModuleLoadedCallback;
+    }
+
+    public String decompileFun(OtpErlangFun fun) throws IOException, OtpErlangException {
+        sendRPC("erlyberly", "saleyn_fun_src", list(fun));
+        OtpErlangString otpString = (OtpErlangString) receiveRPC(5000);
+        return otpString.stringValue();
     }
 }

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -46,8 +46,13 @@ public class OtpUtil {
 
     private static final OtpErlangAtom ERLYBERLY_RECORD_FIELD_ATOM = OtpUtil.atom("erlyberly_record_field");
 
+    public static final HashSet<Class<?>> CONTAINER_TERM_TYPES = new HashSet<Class<?>>(
+        Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class, OtpErlangList.class)
+    );
+
+
     public static final HashSet<Class<?>> LARGE_TERM_TYPES = new HashSet<Class<?>>(
-        Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class, OtpErlangFun.class, OtpErlangExternalFun.class)
+        Arrays.asList(OtpErlangFun.class, OtpErlangExternalFun.class)
     );
 
     private static final OtpErlangAtom TRUE_ATOM = new OtpErlangAtom(true);
@@ -219,19 +224,21 @@ public class OtpUtil {
             return ((OtpErlangList)obj).arity() == 0;
         }
         else if(LARGE_TERM_TYPES.contains(obj.getClass())) {
-            elements = iterableElements(obj);
+            return false;
         }
+        else if(CONTAINER_TERM_TYPES.contains(obj.getClass())) {
+            elements = iterableElements(obj);
+            // short lists and tuples which do not contain other short lists or
+            // tuples are ok
+            if(elements.length > 3)
+                return false;
+            }
         else {
             return true;
         }
 
-        // short lists and tuples which do not contain other short lists or
-        // tuples are ok
-        if(elements.length > 3)
-            return false;
-
         for (OtpErlangObject e : elements) {
-            if(LARGE_TERM_TYPES.contains(e.getClass())) {
+            if(LARGE_TERM_TYPES.contains(e.getClass()) || CONTAINER_TERM_TYPES.contains(e.getClass())) {
                 return false;
             }
             else if(e instanceof OtpErlangString) {

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -27,6 +27,8 @@ import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangBinary;
 import com.ericsson.otp.erlang.OtpErlangDecodeException;
 import com.ericsson.otp.erlang.OtpErlangExit;
+import com.ericsson.otp.erlang.OtpErlangExternalFun;
+import com.ericsson.otp.erlang.OtpErlangFun;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangLong;
 import com.ericsson.otp.erlang.OtpErlangMap;
@@ -45,7 +47,7 @@ public class OtpUtil {
     private static final OtpErlangAtom ERLYBERLY_RECORD_FIELD_ATOM = OtpUtil.atom("erlyberly_record_field");
 
     public static final HashSet<Class<?>> LARGE_TERM_TYPES = new HashSet<Class<?>>(
-        Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class)
+        Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class, OtpErlangFun.class, OtpErlangExternalFun.class)
     );
 
     private static final OtpErlangAtom TRUE_ATOM = new OtpErlangAtom(true);

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -45,7 +45,7 @@ public class OtpUtil {
     private static final OtpErlangAtom ERLYBERLY_RECORD_FIELD_ATOM = OtpUtil.atom("erlyberly_record_field");
 
     public static final HashSet<Class<?>> LARGE_TERM_TYPES = new HashSet<Class<?>>(
-        Arrays.asList(OtpErlangList.class, OtpErlangTuple.class, OtpErlangMap.class)
+        Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class)
     );
 
     private static final OtpErlangAtom TRUE_ATOM = new OtpErlangAtom(true);
@@ -212,7 +212,11 @@ public class OtpUtil {
     public static boolean isLittleTerm(OtpErlangObject obj) {
         OtpErlangObject[] elements;
 
-        if(LARGE_TERM_TYPES.contains(obj.getClass())) {
+        if(obj instanceof OtpErlangList) {
+            // if the list is empty consider it a little term
+            return ((OtpErlangList)obj).arity() == 0;
+        }
+        else if(LARGE_TERM_TYPES.contains(obj.getClass())) {
             elements = iterableElements(obj);
         }
         else {

--- a/src/main/java/erlyberly/node/TraceManager.java
+++ b/src/main/java/erlyberly/node/TraceManager.java
@@ -50,6 +50,12 @@ public class TraceManager {
         return traceList;
     }
 
+    public ArrayList<TraceLog> collateTraceSingle(OtpErlangTuple traceLog) {
+        final ArrayList<TraceLog> traceList = new ArrayList<TraceLog>();
+        decodeTraceLog(traceLog, traceList);
+        return traceList;
+    }
+
     private void decodeTraceLog(OtpErlangObject otpErlangObject, ArrayList<TraceLog> traceList) {
         OtpErlangTuple tup = (OtpErlangTuple) otpErlangObject;
         OtpErlangAtom traceType = (OtpErlangAtom) tup.elementAt(0);

--- a/src/main/java/hextstar/DataRow.java
+++ b/src/main/java/hextstar/DataRow.java
@@ -1,20 +1,3 @@
-/**
- * erlyberly, erlang trace debugger
- * Copyright (C) 2016 Andy Till
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
 package hextstar;
 
 import javafx.beans.property.SimpleStringProperty;

--- a/src/main/java/hextstar/HexstarView.java
+++ b/src/main/java/hextstar/HexstarView.java
@@ -1,20 +1,3 @@
-/**
- * erlyberly, erlang trace debugger
- * Copyright (C) 2016 Andy Till
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- */
 package hextstar;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -1,4 +1,20 @@
 
+%%% erlyberly, erlang trace debugger
+%%% Copyright (C) 2016 Andy Till
+%%%
+%%% This program is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% This program is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 -module(erlyberly).
 
 -export([collect_seq_trace_logs/0]).


### PR DESCRIPTION
Decompile funs to source code.

<img width="1277" alt="screen shot 2016-04-30 at 09 59 55" src="https://cloud.githubusercontent.com/assets/213455/14935010/49431116-0eba-11e6-9ae7-f23e37b3803d.png">

<img width="1185" alt="screen shot 2016-04-30 at 09 58 38" src="https://cloud.githubusercontent.com/assets/213455/14935005/291b1776-0eba-11e6-8a67-7a5adaba9754.png">


The the tracer process inside the remote node now pushes trace logs to erlyberly rather than erlyberly polling for them. This reduces the number of rpc calls being made, which increases the pid numbers.

Fixed some mis-licensing. Trying to get proper attributions and license headers for all the code being used.