### PR TITLE
Fixed delayed traces

### DIFF
--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -157,7 +157,6 @@ public class DbgController implements Initializable {
                 if(collectingTraces && ErlyBerly.nodeAPI().isConnected()) {
                     try {
                         final ArrayList<TraceLog> collectTraceLogs = ErlyBerly.nodeAPI().collectTraceLogs();
-
                         Platform.runLater(() -> { traceLogs.addAll(collectTraceLogs); });
                     } catch (Exception e) {
                         e.printStackTrace();


### PR DESCRIPTION
When a trace was set, sometimes it would take traces five seconds to appear.

This was because the check alive thread would check the mailbox with a timeout of zero so it would return immediately. If it found a special erlyberly message like module loaded then it would process that and recursively call receiveRPC with **NO** timeout, meaning it may block for the default of five seconds if it didn't receive a message in the meantime.