### PR TITLE
Fixed styling for functions that have not completed yet #103

### DIFF
--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -162,6 +162,8 @@ public class DbgTraceView extends VBox {
                     oldTl.isCompleteProperty().removeListener(completeListener);
                 }
                 if (tl != null) {
+
+                    row.pseudoClassStateChanged(notCompletedClass, !row.getItem().isComplete());
                     if("breaker-row".equals(tl.getCssClass())) {
                         row.pseudoClassStateChanged(breakerRowClass, true);
 


### PR DESCRIPTION
Fix for #103 where yellow style for uncompleted functions was not being shown.

<img width="1270" alt="screen shot 2016-05-01 at 15 12 01" src="https://cloud.githubusercontent.com/assets/213455/14942261/251fd3c8-0faf-11e6-975d-7a4fbda99407.png">
