### PR TITLE
multiple code improvements: squid:S1192, squid:S1319, squid:S1905, squid:S1213, squid:S3398

### DIFF
--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -20,6 +20,7 @@ package erlyberly;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import com.ericsson.otp.erlang.OtpErlangException;
@@ -142,7 +143,7 @@ public class DbgController implements Initializable {
             while (true) {
                 if(collectingSeqTraces && ErlyBerly.nodeAPI().isConnected()) {
                     try {
-                        final ArrayList<SeqTraceLog> seqTraceLogs = ErlyBerly.nodeAPI().collectSeqTraceLogs();
+                        final List<SeqTraceLog> seqTraceLogs = ErlyBerly.nodeAPI().collectSeqTraceLogs();
 
                         for (SeqTraceLog seqTraceLog : seqTraceLogs) {
                             Platform.runLater(() -> { callback.callback(seqTraceLog); });

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -23,7 +23,7 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLEncoder;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ResourceBundle;
 
@@ -503,7 +503,7 @@ public class TopBarView implements Initializable {
         @Override
         public void run() {
             try {
-                final HashMap<Object, Object> erlangMemory = ErlyBerly.nodeAPI().erlangMemory();
+                final Map<Object, Object> erlangMemory = ErlyBerly.nodeAPI().erlangMemory();
 
                 // remove stats which are combinations of other stats
                 erlangMemory.remove(OtpUtil.atom("maximum"));
@@ -521,7 +521,7 @@ public class TopBarView implements Initializable {
             }
         }
 
-        private void populatePieData(final HashMap<Object, Object> erlangMemory) {
+        private void populatePieData(final Map<Object, Object> erlangMemory) {
             for (Entry<Object, Object> entry : erlangMemory.entrySet()) {
                 long kb = (long) (Double.parseDouble(entry.getValue().toString()) / 1024);
                 String label = entry.getKey().toString() + " (" + kb + " KB)";


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
squid:S1905 - Redundant casts should not be used.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S3398 - "private" methods called only by inner classes should be moved to those classes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1905
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S3398
Please let me know if you have any questions.
George Kankava