### PR TITLE
Suspend and Unsuspend tracing

### DIFF
--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -51,6 +51,12 @@ public class DbgController implements Initializable {
         ErlyBerly.nodeAPI().setTraceLogCallback((traceLog) -> {
             traceLogs.add(traceLog);
         });
+        ErlyBerly.nodeAPI().suspendedProperty().addListener((o, oldv, suspended) -> {
+            // an un-suspended is similar to a node coming back online, reapply our known traces
+            if(!suspended && ErlyBerly.nodeAPI().isConnected()) {
+                reapplyTraces();
+            }
+        });
         new SeqTraceCollectorThread((seqs) -> { seqTraces.addAll(seqs); }).start();
     }
 

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -212,8 +212,6 @@ public class TopBarView implements Initializable {
         suspendButton.setTooltip(new Tooltip("Toggle Trace Suspension"));
         suspendButton.disableProperty().bind(ErlyBerly.nodeAPI().connectedProperty().not());
         suspendButton.setOnAction((e) -> { suspendTraces(); });
-        // make the width the same as the preferences button, since this button is quite small comparably
-        suspendButton.prefWidthProperty().bind(prefButton.widthProperty());
         // set the default text and icon
         onSuspendedStateChanged(false);
         // listen to when tracing is suspend or not, and update the button text and icon
@@ -259,7 +257,7 @@ public class TopBarView implements Initializable {
 
     private void onSuspendedStateChanged(Boolean suspended) {
         if(suspended) {
-            suspendButton.setText("Un-Suspend");
+            suspendButton.setText("Unsuspend");
             suspendButton.setGraphic(FAIcon.create().icon(AwesomeIcon.PLAY));
         }
         else {

--- a/src/main/resources/erlyberly/topbar.fxml
+++ b/src/main/resources/erlyberly/topbar.fxml
@@ -42,7 +42,7 @@
             <Font size="10.0" />
          </font>
       </Button>
-      <Button fx:id="suspendButton" mnemonicParsing="false" text="Suspend">
+      <Button fx:id="suspendButton" mnemonicParsing="false" text="Unsuspend">
          <font>
             <Font size="10.0" />
          </font>

--- a/src/main/resources/erlyberly/topbar.fxml
+++ b/src/main/resources/erlyberly/topbar.fxml
@@ -42,6 +42,11 @@
             <Font size="10.0" />
          </font>
       </Button>
+      <Button fx:id="suspendButton" mnemonicParsing="false" text="Suspend">
+         <font>
+            <Font size="10.0" />
+         </font>
+      </Button>
    </items>
    <padding>
       <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />


### PR DESCRIPTION
Suspending tracing allows tracing to be stopped on the remote node, and then restarted with the same traces applied.

While tracing is suspended, traces can be added or removed without affecting the remote node. When tracing is unsuspended the traces that have been set in the module tree will be applied.

<img width="1200" alt="screen shot 2016-05-29 at 09 19 13" src="https://cloud.githubusercontent.com/assets/213455/15632066/c93d1382-257e-11e6-931d-c21f23f6dcdc.png">
