### PR TITLE
Overload Protection

### DIFF
--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -82,13 +82,18 @@ public class DbgController implements Initializable {
 
     private void traceModFunc(ModFunc function) {
         try {
-            ErlyBerly.nodeAPI().startTrace(function);
+            ErlyBerly.nodeAPI().startTrace(function, getMaxTraceQueueLengthConfig());
 
             traces.add(function);
         }
         catch (Exception ex) {
             ex.printStackTrace();
         }
+    }
+
+    private int getMaxTraceQueueLengthConfig() {
+        Number maxTraceQueueLength = (Number) PrefBind.getOrDefault("maxTraceQueueLength", 1000);
+        return maxTraceQueueLength.intValue();
     }
 
     private void onRemoveTracer(ActionEvent e, ModFunc function) {
@@ -107,7 +112,7 @@ public class DbgController implements Initializable {
 
         for (ModFunc function : tracesCopy) {
             try {
-                ErlyBerly.nodeAPI().startTrace(function);
+                ErlyBerly.nodeAPI().startTrace(function, getMaxTraceQueueLengthConfig());
             } catch (Exception e) {
                 e.printStackTrace();
 

--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -58,6 +58,12 @@ public class DbgController implements Initializable {
                 reapplyTraces();
             }
         });
+        ErlyBerly.nodeAPI().connectedProperty().addListener(
+            (o, oldV, newV) -> {
+                if(oldV && !newV) {
+                    traceLogs.add(TraceLog.newNodeDown());
+                }
+            });
         new SeqTraceCollectorThread((seqs) -> { seqTraces.addAll(seqs); }).start();
     }
 

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -258,11 +258,13 @@ public class TopBarView implements Initializable {
     private void onSuspendedStateChanged(Boolean suspended) {
         if(suspended) {
             suspendButton.setText("Unsuspend");
-            suspendButton.setGraphic(FAIcon.create().icon(AwesomeIcon.PLAY));
+            suspendButton.setGraphic(FAIcon.create().style("-fx-text-fill: white;").icon(AwesomeIcon.PLAY));
+            suspendButton.getStyleClass().add("button-suspended");
         }
         else {
             suspendButton.setText("Suspend");
             suspendButton.setGraphic(FAIcon.create().icon(AwesomeIcon.PAUSE));
+            suspendButton.getStyleClass().remove("button-suspended");
         }
     }
 

--- a/src/main/java/erlyberly/TraceContextMenu.java
+++ b/src/main/java/erlyberly/TraceContextMenu.java
@@ -85,10 +85,7 @@ public class TraceContextMenu extends ContextMenu {
 
     private void onDelete(ActionEvent e) {
         ArrayList<TraceLog> arrayList = new ArrayList<TraceLog>(selectedItems);
-
-        for (TraceLog traceLog : arrayList) {
-            items.remove(traceLog);
-        }
+        items.removeAll(arrayList);
     }
 
     private void onDeleteAll(ActionEvent e) {

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -310,6 +310,10 @@ public class TraceLog implements Comparable<TraceLog> {
         return new TraceLog("breaker-row", "NODE DOWN");
     }
 
+    public static TraceLog newLoadShedding() {
+        return new TraceLog("breaker-row", "LOAD SHEDDING");
+    }
+
     public OtpErlangList getStackTrace() {
         OtpErlangList stacktrace = (OtpErlangList) map.get(OtpUtil.atom("stack_trace"));
         if(stacktrace == null)

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -69,6 +69,8 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class NodeAPI {
+    private static final OtpErlangAtom ERLYBERLY_TRACE_OVERLOAD_ATOM = atom("erlyberly_trace_overload");
+
     private static final String ERLYBERLY = "erlyberly";
 
     private static final String CANNOT_RUN_THIS_METHOD_FROM_THE_FX_THREAD = "cannot run this method from the FX thread";
@@ -406,6 +408,10 @@ public class NodeAPI {
                     moduleLoadedCallback.callback((OtpErlangTuple) receive.elementAt(2));
             });
             return receiveRPC(timeout);
+        }
+        else if(isTupleTagged(ERLYBERLY_TRACE_OVERLOAD_ATOM, receive)) {
+            Platform.runLater(() -> { suspendedProperty.set(true); });
+
         }
         else if(!isTupleTagged(atom("rex"), receive)) {
             throw new RuntimeException("Expected tuple tagged with atom rex but got " + receive);

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -69,6 +69,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
 public class NodeAPI {
+
     private static final OtpErlangAtom ERLYBERLY_TRACE_OVERLOAD_ATOM = atom("erlyberly_trace_overload");
 
     private static final String ERLYBERLY = "erlyberly";
@@ -86,6 +87,8 @@ public class NodeAPI {
     private static final OtpErlangAtom ERLYBERLY_ATOM = new OtpErlangAtom(ERLYBERLY);
 
     private static final OtpErlangAtom BET_SERVICES_MSG_ATOM = new OtpErlangAtom("add_locator");
+
+    private static final OtpErlangAtom REX_ATOM = atom("rex");
 
     public interface RpcCallback<T> {
         void callback(T result);
@@ -412,9 +415,8 @@ public class NodeAPI {
         }
         else if(isTupleTagged(ERLYBERLY_TRACE_OVERLOAD_ATOM, receive)) {
             Platform.runLater(() -> { suspendedProperty.set(true); });
-
         }
-        else if(!isTupleTagged(atom("rex"), receive)) {
+        else if(!isTupleTagged(REX_ATOM, receive)) {
             throw new RuntimeException("Expected tuple tagged with atom rex but got " + receive);
         }
         OtpErlangObject result = receive.elementAt(1);
@@ -504,19 +506,17 @@ public class NodeAPI {
         return (OtpErlangList) receiveRPC();
     }
 
-    public synchronized void startTrace(ModFunc mf) throws Exception {
+    public synchronized void startTrace(ModFunc mf, int maxQueueLen) throws Exception {
         assert mf.getFuncName() != null : "function name cannot be null";
         // if tracing is suspended, we can't apply a new trace because that will
         // leave us in a state where some traces are active and others are not
         if(isSuspended())
             return;
-        sendRPC(ERLYBERLY, "start_trace", toTraceTuple(mf));
+        sendRPC(ERLYBERLY, "start_trace", toStartTraceFnArgs(mf, maxQueueLen));
 
         OtpErlangObject result = receiveRPC();
-
-        if(isTupleTagged(atom("error"), result)) {
+        if(!isTupleTagged(OK_ATOM, result)) {
             System.out.println(result);
-
 
             // TODO notify caller of failure!
             return;
@@ -544,7 +544,7 @@ public class NodeAPI {
         receiveRPC();
     }
 
-    private OtpErlangList toTraceTuple(ModFunc mf) {
+    private OtpErlangList toStartTraceFnArgs(ModFunc mf, int maxQueueLen) {
         String node = self.node();
         OtpErlangPid self2 = mbox.self();
         return list(
@@ -552,7 +552,7 @@ public class NodeAPI {
             atom(mf.getModuleName()),
             atom(mf.getFuncName()),
             mf.getArity(),
-            mf.isExported()
+            maxQueueLen
         );
     }
 

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -83,11 +83,14 @@ public class OtpUtil {
             if(e instanceof Integer) {
                 tuple[i] = new OtpErlangLong((Integer)e);
             }
+            else if(e instanceof Long) {
+                tuple[i] = new OtpErlangLong((Long)e);
+            }
             else if(e instanceof OtpErlangObject) {
-                tuple[i] = (OtpErlangObject) elements[i];
+                tuple[i] = (OtpErlangObject) e;
             }
             else if(e instanceof String) {
-                tuple[i] = new OtpErlangString((String)elements[i]);
+                tuple[i] = new OtpErlangString((String)e);
             }
             else if(e instanceof Boolean) {
                 if(Boolean.TRUE.equals(e))

--- a/src/main/java/ui/FAIcon.java
+++ b/src/main/java/ui/FAIcon.java
@@ -95,7 +95,7 @@ public class FAIcon extends Label {
     }
 
     public FAIcon style(String style) {
-        setStyle(style);
+        setStyle(getStyle() + style);
         return this;
     }
 

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -239,7 +239,7 @@ erlyberly_tcollector(Node, Pid, Max_queue_len) when is_integer(Max_queue_len) ->
 erlyberly_tcollector2(#tcollector{ ui_pid = UI_pid, max_queue_len = Max_queue_len } = TC) ->
     case process_info(self(), message_queue_len) of
         {message_queue_len, Queue_len} when Queue_len > Max_queue_len ->
-            io:format("STOPPING TRACING"),
+            %% io:format("~nSTOPPING TRACING, Queue Len: ~p, Max Len: ~p~n", [Queue_len, Max_queue_len]),
             ok = dbg:stop_clear(),
             UI_pid ! {erlyberly_trace_overload, Queue_len},
             collect_overloading_logs(Max_queue_len, TC);

--- a/src/main/resources/erlyberly/erlyberly.css
+++ b/src/main/resources/erlyberly/erlyberly.css
@@ -183,3 +183,11 @@
 .mod-src{
     -fx-font: 1.0em "monospace";
 }
+
+.button-suspended {
+    -fx-base: #EE2211;
+}
+.button-suspended:hover {
+    -fx-base: #EE2211;
+    -fx-text-fill: white;
+}


### PR DESCRIPTION
#110 Overload protection on the remote node. The message queue length is checked each time a trace is processed, if it has over a limit tracing is stopped.

<img width="1200" alt="screen shot 2016-05-29 at 16 06 40" src="https://cloud.githubusercontent.com/assets/213455/15634285/eca12212-25b7-11e6-9fd3-02bcd3f7e39b.png">

- [x] Show that tracing is suspended in the UI.
- [x] Configure the message queue length limit.