### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/erlyberly/FilterFocusManager.java
+++ b/src/main/java/erlyberly/FilterFocusManager.java
@@ -34,6 +34,8 @@ public class FilterFocusManager {
 
     private static int lastFocusedIndex = -1;
 
+    private FilterFocusManager() {}
+
     public static void init(Scene scene) {
         FILTERS.add(null);
         FILTERS.add(null);

--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -67,6 +67,8 @@ public class PrefBind {
     private static final Object AWAIT_STORE_LOCK = new Object();
     private static boolean awaitingStore;
 
+    private PrefBind() {}
+
     public static void bind(final String propName, StringProperty stringProp) {
         if(props == null) {
             return;

--- a/src/main/java/erlyberly/format/Formatting.java
+++ b/src/main/java/erlyberly/format/Formatting.java
@@ -24,6 +24,8 @@ import com.ericsson.otp.erlang.OtpErlangBinary;
  */
 class Formatting {
 
+    private Formatting() {}
+
     /**
      * Append the binary term bytes to a string builder. It attempts to display character data
      * as strings.

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -62,6 +62,7 @@ public class OtpUtil {
     private static final OtpErlangAtom ERROR_ATOM = atom("error");
     public static final OtpErlangAtom OK_ATOM = atom("ok");
 
+    private OtpUtil() {}
 
     public static OtpErlangTuple tuple(Object... elements) {
         OtpErlangObject[] tuple = toOtpElementArray(elements);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes 120 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava
