### PR TITLE
squid:S1319 - Declarations should use Java collection interfaces such as ‘List’ rather than specific implementation classes such as ‘LinkedList’

### DIFF
--- a/src/main/java/erlyberly/CrashReport.java
+++ b/src/main/java/erlyberly/CrashReport.java
@@ -19,8 +19,8 @@ package erlyberly;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import com.ericsson.otp.erlang.OtpErlangAtom;
@@ -47,7 +47,7 @@ public class CrashReport {
 
     private static final OtpErlangAtom ATOM_LINE = OtpUtil.atom("line");
 
-    private final HashMap<Object, Object> crashProps;
+    private final Map<Object, Object> crashProps;
 
     private final String registeredName;
 
@@ -89,7 +89,7 @@ public class CrashReport {
                 OtpErlangList list = (OtpErlangList) argsOrArity;
                 arity = new OtpErlangLong(list.arity());
             }
-            HashMap<Object, Object> fileLineProps = OtpUtil.propsToMap((OtpErlangList) tuple.elementAt(3));
+            Map<Object, Object> fileLineProps = OtpUtil.propsToMap((OtpErlangList) tuple.elementAt(3));
             OtpErlangString file = (OtpErlangString) fileLineProps.get(ATOM_FILE);
             OtpErlangLong line = (OtpErlangLong) fileLineProps.get(ATOM_LINE);
 

--- a/src/main/java/erlyberly/SeqTraceLog.java
+++ b/src/main/java/erlyberly/SeqTraceLog.java
@@ -17,7 +17,7 @@
  */
 package erlyberly;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangString;
@@ -42,7 +42,7 @@ public class SeqTraceLog {
         this.timestamp = timestamp;
     }
 
-    public static SeqTraceLog build(HashMap<Object, Object> props) {
+    public static SeqTraceLog build(Map<Object, Object> props) {
         Object msgType = props.get(OtpUtil.atom("msg_type"));
         Object serial = props.get(OtpUtil.atom("serial"));
         Object from = props.get(OtpUtil.atom("from"));

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -18,6 +18,7 @@
 package erlyberly;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.ericsson.otp.erlang.OtpErlangAtom;
@@ -46,7 +47,7 @@ public class TraceLog implements Comparable<TraceLog> {
 
     private static final AtomicLong INSTANCE_COUNTER = new AtomicLong();
 
-    private final HashMap<Object, Object> map;
+    private final Map<Object, Object> map;
 
     private final long instanceNum;
 
@@ -64,7 +65,7 @@ public class TraceLog implements Comparable<TraceLog> {
 
     private final String cssClass;
 
-    public TraceLog(HashMap<Object, Object> map) {
+    public TraceLog(Map<Object, Object> map) {
         this.map = map;
         instanceNum = INSTANCE_COUNTER.incrementAndGet();
         pid = getPidString();
@@ -219,7 +220,7 @@ public class TraceLog implements Comparable<TraceLog> {
         return Long.compare(instanceNum, o.instanceNum);
     }
 
-    public void complete(HashMap<Object, Object> resultMap) {
+    public void complete(Map<Object, Object> resultMap) {
         tracePropsToString = null;
         Object e = resultMap.get(EXCEPTION_FROM_ATOM);
         Object ts = resultMap.get(TIMESTAMP_RETURN_ATOM);

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -427,7 +426,7 @@ public class NodeAPI {
     private void traceLogNotification(OtpErlangTuple receive) {
         Platform.runLater(() -> {
             OtpErlangTuple traceLog = (OtpErlangTuple) receive.elementAt(1);
-            ArrayList<TraceLog> collatedTraces = traceManager.collateTraceSingle(traceLog);
+            List<TraceLog> collatedTraces = traceManager.collateTraceSingle(traceLog);
             if(traceLogCallback != null) {
                 for (TraceLog log : collatedTraces) {
                     traceLogCallback.callback(log);
@@ -471,7 +470,7 @@ public class NodeAPI {
             for (OtpErlangObject recv : received) {
                 if(recv instanceof OtpErlangList) {
                     OtpErlangList pinfo = (OtpErlangList) recv;
-                    HashMap<Object, Object> propsToMap = OtpUtil.propsToMap(pinfo);
+                    Map<Object, Object> propsToMap = OtpUtil.propsToMap(pinfo);
                     processes.add(ProcInfo.toProcessInfo(propsToMap));
                 }
                 }

--- a/src/main/java/erlyberly/node/OtpUtil.java
+++ b/src/main/java/erlyberly/node/OtpUtil.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import com.ericsson.otp.erlang.OtpConn;
 import com.ericsson.otp.erlang.OtpErlangAtom;
@@ -46,12 +48,12 @@ public class OtpUtil {
 
     private static final OtpErlangAtom ERLYBERLY_RECORD_FIELD_ATOM = OtpUtil.atom("erlyberly_record_field");
 
-    public static final HashSet<Class<?>> CONTAINER_TERM_TYPES = new HashSet<Class<?>>(
+    public static final Set<Class<?>> CONTAINER_TERM_TYPES = new HashSet<Class<?>>(
         Arrays.asList(OtpErlangTuple.class, OtpErlangMap.class, OtpErlangList.class)
     );
 
 
-    public static final HashSet<Class<?>> LARGE_TERM_TYPES = new HashSet<Class<?>>(
+    public static final Set<Class<?>> LARGE_TERM_TYPES = new HashSet<Class<?>>(
         Arrays.asList(OtpErlangFun.class, OtpErlangExternalFun.class)
     );
 
@@ -110,7 +112,7 @@ public class OtpUtil {
     /**
      * Take an {@link OtpErlangList} of erlang key value tuples and converts it to a map.
      */
-    public static HashMap<Object, Object> propsToMap(OtpErlangList pinfo) {
+    public static Map<Object, Object> propsToMap(OtpErlangList pinfo) {
         HashMap<Object, Object> map = new HashMap<>();
         for (OtpErlangObject otpErlangObject : pinfo) {
             if(otpErlangObject instanceof OtpErlangTuple && ((OtpErlangTuple) otpErlangObject).arity() == 2) {

--- a/src/main/java/erlyberly/node/TraceManager.java
+++ b/src/main/java/erlyberly/node/TraceManager.java
@@ -19,6 +19,8 @@ package erlyberly.node;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Stack;
 
 import com.ericsson.otp.erlang.OtpErlangAtom;
@@ -40,7 +42,7 @@ public class TraceManager {
     private final HashMap<String, Stack<TraceLog>> unfinishedCalls = new HashMap<String, Stack<TraceLog>>();
 
 
-    public ArrayList<TraceLog> collateTraces(OtpErlangList traceLogs) {
+    public List<TraceLog> collateTraces(OtpErlangList traceLogs) {
         final ArrayList<TraceLog> traceList = new ArrayList<TraceLog>();
 
         for (OtpErlangObject obj : traceLogs) {
@@ -50,7 +52,7 @@ public class TraceManager {
         return traceList;
     }
 
-    public ArrayList<TraceLog> collateTraceSingle(OtpErlangTuple traceLog) {
+    public List<TraceLog> collateTraceSingle(OtpErlangTuple traceLog) {
         final ArrayList<TraceLog> traceList = new ArrayList<TraceLog>();
         decodeTraceLog(traceLog, traceList);
         return traceList;
@@ -75,7 +77,7 @@ public class TraceManager {
             traceList.add(trace);
         }
         else if(RETURN_FROM_ATOM.equals(traceType) || EXCEPTION_FROM_ATOM.equals(traceType)) {
-            HashMap<Object, Object> map = propsFromTrace(tup);
+            Map<Object, Object> map = propsFromTrace(tup);
 
             Object object = map.get(TraceLog.ATOM_PID);
 
@@ -97,14 +99,14 @@ public class TraceManager {
     }
 
     private TraceLog proplistToTraceLog(OtpErlangTuple tup) {
-        HashMap<Object, Object> map = propsFromTrace(tup);
+        Map<Object, Object> map = propsFromTrace(tup);
 
         TraceLog trace = new TraceLog(map);
 
         return trace;
     }
 
-    private HashMap<Object, Object> propsFromTrace(OtpErlangTuple tup) {
+    private Map<Object, Object> propsFromTrace(OtpErlangTuple tup) {
         return OtpUtil.propsToMap((OtpErlangList) tup.elementAt(1));
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1319 - Declarations should use Java collection interfaces such as ‘List’ rather than specific implementation classes such as ‘LinkedList’.
This pull request removes 80 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
George Kankava
