### PR TITLE
Stop duplicate preferences tabs being shown

### DIFF
--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -271,7 +271,8 @@ public class ErlyBerly extends Application {
             FxmlLoadable fxmlLoadable = new FxmlLoadable("/erlyberly/preferences.fxml");
             Parent parent = fxmlLoadable.load();
             Pane tabPane = ErlyBerly.wrapInPane(parent);
-            prefstab = new Tab("Preferences", tabPane);
+            prefstab = new Tab("Preferences");
+            prefstab.setContent(tabPane);
         }
 
         if(tabPane.getTabs().contains(prefstab)) {

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -47,6 +47,12 @@ public class ErlyBerly extends Application {
 
     private static final NodeAPI NODE_API = new NodeAPI();
 
+    /**
+     * The preferences tab, that is added when the user presses the 'Preferences'
+     * button in the top bar. Static because there can be only one.
+     */
+    private static Tab prefstab;
+
     private SplitPane splitPane;
 
     private Region entopPane;
@@ -251,8 +257,29 @@ public class ErlyBerly extends Application {
         Tab newTab;
         newTab = new Tab(title);
         newTab.setContent(parentControl);
+        addAndSelectTab(newTab);
+    }
+
+    private static void addAndSelectTab(Tab newTab) {
         tabPane.getTabs().add(newTab);
         tabPane.getSelectionModel().select(newTab);
+    }
+
+
+    public static void showPreferencesPane() {
+        if(prefstab == null) {
+            FxmlLoadable fxmlLoadable = new FxmlLoadable("/erlyberly/preferences.fxml");
+            Parent parent = fxmlLoadable.load();
+            Pane tabPane = ErlyBerly.wrapInPane(parent);
+            prefstab = new Tab("Preferences", tabPane);
+        }
+
+        if(tabPane.getTabs().contains(prefstab)) {
+            tabPane.getSelectionModel().select(prefstab);
+        }
+        else {
+            addAndSelectTab(prefstab);
+        }
     }
 
     /**

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -522,10 +522,7 @@ public class TopBarView implements Initializable {
     }
 
     private void displayPreferencesPane() {
-        ErlyBerly.showPane(
-            "Preferences",
-            ErlyBerly.wrapInPane(new FxmlLoadable("/erlyberly/preferences.fxml").load())
-        );
+        ErlyBerly.showPreferencesPane();
     }
 
     class ErlangMemoryThread extends Thread {


### PR DESCRIPTION
Fixes #90

Subsequent clicks on 'Preferences' will show the original preferences pane.