### PR TITLE
xref hardening

### DIFF
--- a/src/main/java/erlyberly/CallGraphView.java
+++ b/src/main/java/erlyberly/CallGraphView.java
@@ -70,6 +70,7 @@ public class CallGraphView extends TreeView<ModFunc> {
     }
 
     public void callGraph(OtpErlangTuple callStack) {
+        assert callStack != null;
         populateCallGraph(getRoot(), callStack);
     }
 
@@ -80,6 +81,7 @@ public class CallGraphView extends TreeView<ModFunc> {
      * </code>
      */
     private void populateCallGraph(TreeItem<ModFunc> parentModFuncItem, OtpErlangTuple callGraph) {
+        assert callGraph != null;
         OtpErlangTuple mfaTuple = (OtpErlangTuple) OtpUtil.tupleElement(0, callGraph);
         OtpErlangList calls = (OtpErlangList) OtpUtil.tupleElement(1, callGraph);
 

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -153,6 +153,9 @@ public class NodeAPI {
             @Override
             public void changed(ObservableValue<? extends Boolean> obv, Boolean o, Boolean n) {
                 connected = n;
+                if(!n) {
+                    xrefStartedProperty.set(false);
+                }
             }});
         summary = new SimpleStringProperty("erlyberly not connected");
 

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -669,8 +669,8 @@ public class NodeAPI {
         return manuallyDisconnected;
     }
 
-    public synchronized OtpErlangObject callGraph(OtpErlangAtom module, OtpErlangAtom function, OtpErlangLong arity) throws IOException, OtpErlangException {
-        sendRPC(ERLYBERLY, "xref_analysis", list(module, function, arity));
+    public synchronized OtpErlangObject callGraph(OtpErlangList skippedModuleAtoms, OtpErlangAtom module, OtpErlangAtom function, OtpErlangLong arity) throws IOException, OtpErlangException {
+        sendRPC(ERLYBERLY, "xref_analysis", list(skippedModuleAtoms, module, function, arity));
 
         OtpErlangObject result = receiveRPC();
 

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -624,15 +624,10 @@ is_xref_recursion(_,_) ->
 
 %%
 ensure_xref_started() ->
-    case whereis(?erlyberly_xref) of
-        undefined ->
-            {ok, _} = xref:start(?erlyberly_xref),
-            % timer:sleep(1000),
-            [xref:add_directory(?erlyberly_xref, Dir) || Dir <- code:get_path()],
-            {erlyberly_xref_started};
-        _ ->
-            {erlyberly_xref_started}
-    end.
+    catch xref:stop(?erlyberly_xref),
+    {ok, _} = xref:start(?erlyberly_xref),
+    [xref:add_directory(?erlyberly_xref, Dir) || Dir <- code:get_path()],
+    {erlyberly_xref_started}.
 
 %%% ============================================================================
 %%% view module source code

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -32,7 +32,7 @@
 -export([start_trace/5]).
 -export([stop_trace/4]).
 -export([stop_traces/0]).
--export([xref_analysis/3]).
+-export([xref_analysis/4]).
 
 %% exported for spawned processes
 -export([erlyberly_tcollector/3]).
@@ -605,16 +605,22 @@ seq_trace_match_spec(_) ->
 -define(erlyberly_xref, erlyberly_xref).
 
 %%
-xref_analysis(M,F,A) when is_integer(A) ->
-    % TODO monitor the node and stop the erlyberly xref
-    ensure_xref_started(),
-
-    xref_analysis2({M,F,A}, []).
+xref_analysis(Ignore_mods, M,F,A) when is_integer(A) ->
+    Call_stack_set = gb_sets:new(),
+    xref_analysis2({M,F,A}, gb_sets:from_list(Ignore_mods), Call_stack_set, []).
 
 %%
-xref_analysis2(MFA, Call_stack) ->
-    {ok, Calls} = xref:analyze(?erlyberly_xref, {call, MFA}),
-    {MFA, [xref_analysis2(X_mfa, [MFA | Call_stack]) || X_mfa <- Calls, not is_xref_recursion(MFA, X_mfa) andalso not lists:member(MFA, Call_stack)]}.
+xref_analysis2(MFA, Ignore_mods_set, All_calls, Call_stack) ->
+    case gb_sets:is_member(MFA, All_calls) orelse gb_sets:is_member(element(1,MFA), Ignore_mods_set) of
+        true ->
+            {MFA, []};
+        false ->
+            {ok, Calls} = xref:analyze(?erlyberly_xref, {call, MFA}),
+            All_calls2 = gb_sets:add(MFA, All_calls),
+            Analysed_calls =
+                [xref_analysis2(X_mfa, Ignore_mods_set, All_calls2, [MFA | Call_stack]) || X_mfa <- Calls, not is_xref_recursion(MFA, X_mfa)],
+            {MFA, Analysed_calls}
+    end.
 
 %%
 is_xref_recursion({M,F,A}, {M,F,A}) ->
@@ -626,8 +632,17 @@ is_xref_recursion(_,_) ->
 ensure_xref_started() ->
     catch xref:stop(?erlyberly_xref),
     {ok, _} = xref:start(?erlyberly_xref),
-    [xref:add_directory(?erlyberly_xref, Dir) || Dir <- code:get_path()],
+    Excluded = ["asn1ct", "/ct-", "dialyzer", "diameter", "hipe", "httpd", "megaco", "xmerl", "wx-"],
+    [xref:add_directory(?erlyberly_xref, Dir) || Dir <- code:get_path(), not dir_contains(Dir, Excluded)],
     {erlyberly_xref_started}.
+
+dir_contains(_, []) ->
+    false;
+dir_contains(Dir, [Str|Tail]) ->
+    case string:str(Dir, Str) of
+        0 -> dir_contains(Dir, Tail);
+        _ -> true
+    end.
 
 %%% ============================================================================
 %%% view module source code


### PR DESCRIPTION
Fix xref bugs, improve stability and usability.

* Show a spinner when xref is analysing
* Always run an initial xref indexing, even when the erlyberly xref process already exists.
* Skip indexing of some obscure standard library apps, megaco etc.
* Skip analysis of many standard lib modules
* Protect against getting into an infinite loop by maintaining a call stack and checking that the current call is not in it.