### PR TITLE
Handle cases where the file is not given in the crash props

### DIFF
--- a/src/main/java/erlyberly/CrashReport.java
+++ b/src/main/java/erlyberly/CrashReport.java
@@ -93,8 +93,12 @@ public class CrashReport {
             OtpErlangString file = (OtpErlangString) fileLineProps.get(ATOM_FILE);
             OtpErlangLong line = (OtpErlangLong) fileLineProps.get(ATOM_LINE);
 
+            String fileString = "";
+            if(file != null) {
+                fileString = file.stringValue();
+            }
             result.add(
-                fn.invoke(module, function, arity, file.stringValue(), line)
+                fn.invoke(module, function, arity, fileString, line)
             );
         }
         return result;


### PR DESCRIPTION
Fixed #92, crash reports do not open because a `NullPointerException` is thrown when there is no file property in the crash report.

Now checks for nulls.  The file is not shown in the stack trace if the file property is not given.