### PR TITLE
Display as string only if all chars are displayable

### DIFF
--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -20,6 +20,7 @@ package erlyberly;
 import java.io.IOException;
 
 import erlyberly.format.ErlangFormatter;
+import erlyberly.format.LFEFormatter;
 import erlyberly.format.TermFormatter;
 import erlyberly.node.NodeAPI;
 import javafx.application.Application;
@@ -61,7 +62,7 @@ public class ErlyBerly extends Application {
 
     private static TabPane tabPane;
 
-    private static TermFormatter termFormatter = new ErlangFormatter();
+    private static TermFormatter termFormatter;
 
     public static void main(String[] args) throws Exception {
         launch(args);
@@ -74,6 +75,7 @@ public class ErlyBerly extends Application {
         } catch (IOException e) {
             e.printStackTrace();
         }
+        termFormatter = formatterFromConfig();
 
         FxmlLoadable topBarFxml;
         topBarFxml = new FxmlLoadable("/erlyberly/topbar.fxml");
@@ -154,6 +156,16 @@ public class ErlyBerly extends Application {
             sizeSplitPanes(splitPane);
             dbgView.sizeSplitPanes();
         });
+    }
+
+    private static TermFormatter formatterFromConfig() {
+        String formattingPref = PrefBind.getOrDefault("termFormatting", "erlang").toString();
+        if("erlang".equals(formattingPref))
+            return new ErlangFormatter();
+        else if("lfe".equals(formattingPref))
+            return new LFEFormatter();
+        else
+            throw new RuntimeException("Invalid configuration for property 'termFormatting' it must be 'erlang' or 'lfe' but was " + formattingPref);
     }
 
     public static void applyCssToWIndow(Scene scene) {

--- a/src/main/java/erlyberly/PreferencesView.java
+++ b/src/main/java/erlyberly/PreferencesView.java
@@ -70,10 +70,14 @@ public class PreferencesView implements Initializable {
     }
 
     private void storeFormattingPreferenceChange() {
-        if(erlangTermsButton.isSelected())
+        if(erlangTermsButton.isSelected()) {
             PrefBind.set("termFormatting", "erlang");
-        else if(lfeTermsButton.isSelected())
+            ErlyBerly.setTermFormatter(new ErlangFormatter());
+        }
+        else if(lfeTermsButton.isSelected()) {
             PrefBind.set("termFormatting", "lfe");
+            ErlyBerly.setTermFormatter(new LFEFormatter());
+        }
         selectFormattingButton();
     }
 
@@ -81,11 +85,9 @@ public class PreferencesView implements Initializable {
         String formattingPref = PrefBind.getOrDefault("termFormatting", "erlang").toString();
         if("erlang".equals(formattingPref)) {
             erlangTermsButton.setSelected(true);
-            ErlyBerly.setTermFormatter(new ErlangFormatter());
         }
         else if("lfe".equals(formattingPref)) {
             lfeTermsButton.setSelected(true);
-            ErlyBerly.setTermFormatter(new LFEFormatter());
         }
         else
             throw new RuntimeException("Invalid configuration for property 'termFormatting' it must be 'erlang' or 'lfe' but was " + formattingPref);

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -79,49 +79,12 @@ public class ErlangFormatter implements TermFormatter {
             sb.append(brackets.charAt(1));
         }
         else if(obj instanceof OtpErlangString) {
-            OtpErlangString aString = (OtpErlangString) obj;
-            appendString(aString, sb);
+            Formatting.appendString((OtpErlangString) obj, this, sb);
         }
         else {
             sb.append(obj.toString());
         }
         return sb;
-    }
-
-    private void appendString(OtpErlangString aString, StringBuilder sb) {
-        String stringValue = aString.stringValue();
-        // sometimes a list of integers can be mis-typed by jinterface as a string
-        // in this case we format it ourselves as a list of ints
-        boolean isString = isString(stringValue);
-        if(isString) {
-            sb.append(stringValue.replace("\n", "\\n"));
-        }
-        else {
-            appendListOfInts(stringValue, sb);
-        }
-    }
-
-    private void appendListOfInts(String stringValue, StringBuilder sb) {
-        sb.append("[");
-        for (int i = 0; i < stringValue.length(); i++) {
-            int c = stringValue.charAt(i);
-            sb.append(c);
-            if(i < (stringValue.length() - 1)) {
-                sb.append(",");
-            }
-        }
-        sb.append("]");
-    }
-
-    private boolean isString(String stringValue) {
-        int length = stringValue.length();
-        for (int i = 0; i < length; i++) {
-            char c = stringValue.charAt(i);
-            if(c < 10 || c > 127) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private static String pidToString(OtpErlangPid pid) {

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -73,12 +73,49 @@ public class ErlangFormatter implements TermFormatter {
             sb.append(brackets.charAt(1));
         }
         else if(obj instanceof OtpErlangString) {
-            sb.append(obj.toString().replace("\n", "\\n"));
+            OtpErlangString aString = (OtpErlangString) obj;
+            appendString(aString, sb);
         }
         else {
             sb.append(obj.toString());
         }
         return sb;
+    }
+
+    private void appendString(OtpErlangString aString, StringBuilder sb) {
+        String stringValue = aString.stringValue();
+        // sometimes a list of integers can be mis-typed by jinterface as a string
+        // in this case we format it ourselves as a list of ints
+        boolean isString = isString(stringValue);
+        if(isString) {
+            sb.append(stringValue.replace("\n", "\\n"));
+        }
+        else {
+            appendListOfInts(stringValue, sb);
+        }
+    }
+
+    private void appendListOfInts(String stringValue, StringBuilder sb) {
+        sb.append("[");
+        for (int i = 0; i < stringValue.length(); i++) {
+            int c = stringValue.charAt(i);
+            sb.append(c);
+            if(i < (stringValue.length() - 1)) {
+                sb.append(",");
+            }
+        }
+        sb.append("]");
+    }
+
+    private boolean isString(String stringValue) {
+        int length = stringValue.length();
+        for (int i = 0; i < length; i++) {
+            char c = stringValue.charAt(i);
+            if(c < 10 || c > 127) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String pidToString(OtpErlangPid pid) {

--- a/src/main/java/erlyberly/format/Formatting.java
+++ b/src/main/java/erlyberly/format/Formatting.java
@@ -27,21 +27,21 @@ class Formatting {
 
     private Formatting() {}
 
-    public static void appendString(OtpErlangString aString, StringBuilder sb) {
+    public static void appendString(OtpErlangString aString, TermFormatter formatter, StringBuilder sb) {
         String stringValue = aString.stringValue();
         // sometimes a list of integers can be mis-typed by jinterface as a string
         // in this case we format it ourselves as a list of ints
         boolean isString = isString(stringValue);
         if(isString) {
-            sb.append(stringValue.replace("\n", "\\n"));
+            sb.append("\"").append(stringValue.replace("\n", "\\n")).append("\"");
         }
         else {
-            appendListOfInts(stringValue, sb);
+            appendListOfInts(stringValue, formatter, sb);
         }
     }
 
-    private static void appendListOfInts(String stringValue, StringBuilder sb) {
-        sb.append("[");
+    private static void appendListOfInts(String stringValue, TermFormatter formatter, StringBuilder sb) {
+        sb.append(formatter.listLeftParen());
         for (int i = 0; i < stringValue.length(); i++) {
             int c = stringValue.charAt(i);
             sb.append(c);
@@ -49,7 +49,7 @@ class Formatting {
                 sb.append(",");
             }
         }
-        sb.append("]");
+        sb.append(formatter.listRightParen());
     }
 
     private static boolean isString(String stringValue) {

--- a/src/main/java/erlyberly/format/Formatting.java
+++ b/src/main/java/erlyberly/format/Formatting.java
@@ -18,11 +18,48 @@
 package erlyberly.format;
 
 import com.ericsson.otp.erlang.OtpErlangBinary;
+import com.ericsson.otp.erlang.OtpErlangString;
 
 /**
  * Utility methods for formatting.
  */
 class Formatting {
+
+    public static void appendString(OtpErlangString aString, StringBuilder sb) {
+        String stringValue = aString.stringValue();
+        // sometimes a list of integers can be mis-typed by jinterface as a string
+        // in this case we format it ourselves as a list of ints
+        boolean isString = isString(stringValue);
+        if(isString) {
+            sb.append(stringValue.replace("\n", "\\n"));
+        }
+        else {
+            appendListOfInts(stringValue, sb);
+        }
+    }
+
+    private static void appendListOfInts(String stringValue, StringBuilder sb) {
+        sb.append("[");
+        for (int i = 0; i < stringValue.length(); i++) {
+            int c = stringValue.charAt(i);
+            sb.append(c);
+            if(i < (stringValue.length() - 1)) {
+                sb.append(",");
+            }
+        }
+        sb.append("]");
+    }
+
+    private static boolean isString(String stringValue) {
+        int length = stringValue.length();
+        for (int i = 0; i < length; i++) {
+            char c = stringValue.charAt(i);
+            if(c < 10 || c > 127) {
+                return false;
+            }
+        }
+        return true;
+    }
 
     /**
      * Append the binary term bytes to a string builder. It attempts to display character data

--- a/src/main/java/erlyberly/format/LFEFormatter.java
+++ b/src/main/java/erlyberly/format/LFEFormatter.java
@@ -100,7 +100,7 @@ public class LFEFormatter implements TermFormatter {
             sb.append(")");
         }
         else if(obj instanceof OtpErlangString) {
-            sb.append(obj.toString().replace("\n", "\\n"));
+            Formatting.appendString((OtpErlangString) obj, this, sb);
         }
         else {
             sb.append(obj.toString());
@@ -139,7 +139,7 @@ public class LFEFormatter implements TermFormatter {
 
     @Override
     public String listLeftParen() {
-        return ")";
+        return "(";
     }
 
     @Override


### PR DESCRIPTION
When jinterface decodes a list of ints it returns the type of OtpErlangString, even though the list is not displayable, and was not intended to be a string.

This change checks that all chars are displayable, and will display the term as an OtpErlangList if it cannot.
- [x] Check this hasn't broken utf8
- [x] Fix for LFE
