### PR TITLE
Add support for improper lists.

### DIFF
--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -209,6 +209,10 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                     for (OtpErlangObject e : elements) {
                         addToTreeItem(listItem, e);
                     }
+                    if (!((OtpErlangList)obj).isProper()) {
+                        listItem.getChildren().add(new TreeItem<>(new TermTreeItem(obj, f.cons())));
+                        addToTreeItem(listItem, ((OtpErlangList)obj).getLastTail());
+                    }
                     parent.getChildren().add(listItem);
                     parent.getChildren().add(new TreeItem<>(new TermTreeItem(obj, f.listRightParen())));
                 }

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -70,6 +70,12 @@ public class ErlangFormatter implements TermFormatter {
                 }
                 appendToString(elements[i], sb);
             }
+
+            if(obj instanceof OtpErlangList && !((OtpErlangList)obj).isProper()) {
+                sb.append(cons());
+                appendToString(((OtpErlangList)obj).getLastTail(), sb);
+            }
+
             sb.append(brackets.charAt(1));
         }
         else if(obj instanceof OtpErlangString) {
@@ -166,5 +172,10 @@ public class ErlangFormatter implements TermFormatter {
     @Override
     public String listRightParen() {
         return "]";
+    }
+
+    @Override
+    public String cons() {
+        return "|";
     }
 }

--- a/src/main/java/erlyberly/format/LFEFormatter.java
+++ b/src/main/java/erlyberly/format/LFEFormatter.java
@@ -93,6 +93,10 @@ public class LFEFormatter implements TermFormatter {
         else if(obj instanceof OtpErlangList) {
             sb.append("(");
             elementsToString(sb, ((OtpErlangList) obj).elements());
+            if(!((OtpErlangList) obj).isProper()) {
+                sb.append(cons());
+                appendToString(((OtpErlangList) obj).getLastTail(), sb);
+            }
             sb.append(")");
         }
         else if(obj instanceof OtpErlangString) {
@@ -141,5 +145,10 @@ public class LFEFormatter implements TermFormatter {
     @Override
     public String listRightParen() {
         return ")";
+    }
+
+    @Override
+    public String cons() {
+        return ".";
     }
 }

--- a/src/main/java/erlyberly/format/TermFormatter.java
+++ b/src/main/java/erlyberly/format/TermFormatter.java
@@ -50,4 +50,6 @@ public interface TermFormatter {
     String listLeftParen();
 
     String listRightParen();
+
+    String cons();
 }

--- a/src/test/java/erlyberly/node/OtpUtilTest.java
+++ b/src/test/java/erlyberly/node/OtpUtilTest.java
@@ -20,9 +20,14 @@ package erlyberly.node;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangBinary;
+import com.ericsson.otp.erlang.OtpErlangException;
+import com.ericsson.otp.erlang.OtpErlangList;
+import com.ericsson.otp.erlang.OtpErlangObject;
 
 import erlyberly.format.ErlangFormatter;
+import erlyberly.format.LFEFormatter;
 
 
 public class OtpUtilTest  {
@@ -121,6 +126,35 @@ public class OtpUtilTest  {
 		Assert.assertEquals("{1, 2, {3, 4}}", sb.toString());
 	}
 	*/
+
+    @Test
+    public void improperListErlang() throws OtpErlangException {
+        OtpErlangList improper =
+            new OtpErlangList(
+                    new OtpErlangObject[] {
+                        new OtpErlangAtom("hello"),
+                        new OtpErlangBinary("x".getBytes()),
+                    },
+                    new OtpErlangAtom("world"));
+        Assert.assertEquals(
+                "[hello, <<\"x\">>|world]",
+                new ErlangFormatter().toString(improper));
+    }
+
+    @Test
+    public void improperListLFE() throws OtpErlangException {
+        OtpErlangList improper =
+            new OtpErlangList(
+                    new OtpErlangObject[] {
+                        new OtpErlangAtom("hello"),
+                        new OtpErlangBinary("x".getBytes()),
+                    },
+                    new OtpErlangAtom("world"));
+        Assert.assertEquals(
+                "('hello, #B(\"x\").'world)",
+                new LFEFormatter().toString(improper));
+    }
+
 	private String bin() {
 		OtpErlangBinary binary = new OtpErlangBinary(bytes);
 		


### PR DESCRIPTION
The problem was that the last element of an improper list would be dropped, i.e.

[a,b,c|d] would be formatted as [a,b,c]

Now it will be formatted as [a, b, c|d]