### PR TITLE
Add support for displaying in Elixir format

### DIFF
--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -20,6 +20,7 @@ package erlyberly;
 import java.io.IOException;
 
 import erlyberly.format.ErlangFormatter;
+import erlyberly.format.ElixirFormatter;
 import erlyberly.format.LFEFormatter;
 import erlyberly.format.TermFormatter;
 import erlyberly.node.NodeAPI;
@@ -162,6 +163,8 @@ public class ErlyBerly extends Application {
         String formattingPref = PrefBind.getOrDefault("termFormatting", "erlang").toString();
         if("erlang".equals(formattingPref))
             return new ErlangFormatter();
+        else if("elixir".equals(formattingPref))
+            return new ElixirFormatter();
         else if("lfe".equals(formattingPref))
             return new LFEFormatter();
         else

--- a/src/main/java/erlyberly/PreferencesView.java
+++ b/src/main/java/erlyberly/PreferencesView.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.ResourceBundle;
 
 import erlyberly.format.ErlangFormatter;
+import erlyberly.format.ElixirFormatter;
 import erlyberly.format.LFEFormatter;
 import javafx.beans.Observable;
 import javafx.fxml.FXML;
@@ -47,6 +48,8 @@ public class PreferencesView implements Initializable {
     @FXML
     private RadioButton erlangTermsButton;
     @FXML
+    private RadioButton elixirTermsButton;
+    @FXML
     private RadioButton lfeTermsButton;
 
     @Override
@@ -59,6 +62,7 @@ public class PreferencesView implements Initializable {
             storeFormattingPreferenceChange();
         });
         erlangTermsButton.setToggleGroup(group);
+        elixirTermsButton.setToggleGroup(group);
         lfeTermsButton.setToggleGroup(group);
 
         PrefBind.bind("targetNodeName", nodeNameField.textProperty());
@@ -74,6 +78,10 @@ public class PreferencesView implements Initializable {
             PrefBind.set("termFormatting", "erlang");
             ErlyBerly.setTermFormatter(new ErlangFormatter());
         }
+        else if(elixirTermsButton.isSelected()) {
+            PrefBind.set("termFormatting", "elixir");
+            ErlyBerly.setTermFormatter(new ElixirFormatter());
+        }
         else if(lfeTermsButton.isSelected()) {
             PrefBind.set("termFormatting", "lfe");
             ErlyBerly.setTermFormatter(new LFEFormatter());
@@ -85,6 +93,9 @@ public class PreferencesView implements Initializable {
         String formattingPref = PrefBind.getOrDefault("termFormatting", "erlang").toString();
         if("erlang".equals(formattingPref)) {
             erlangTermsButton.setSelected(true);
+        }
+        else if("elixir".equals(formattingPref)) {
+            elixirTermsButton.setSelected(true);
         }
         else if("lfe".equals(formattingPref)) {
             lfeTermsButton.setSelected(true);

--- a/src/main/java/erlyberly/format/ElixirFormatter.java
+++ b/src/main/java/erlyberly/format/ElixirFormatter.java
@@ -93,7 +93,12 @@ public class ElixirFormatter implements TermFormatter {
         }
         else if(obj instanceof OtpErlangAtom){
             sb.append(":");
-            sb.append(obj.toString());
+            String str = obj.toString();
+            if (str.startsWith("\'") && str.endsWith("\'")) {
+                // Convert Erlang style escaped atoms to Elixir style
+                str = "\"" + str.substring(1, str.length() - 1) + "\"";
+            }
+            sb.append(str);
         }
         else if(obj instanceof OtpErlangMap) {
             sb.append("%{");

--- a/src/main/java/erlyberly/format/ElixirFormatter.java
+++ b/src/main/java/erlyberly/format/ElixirFormatter.java
@@ -17,26 +17,36 @@
  */
 package erlyberly.format;
 
-import java.util.ArrayList;
-
-import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangBinary;
-import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangPid;
-import com.ericsson.otp.erlang.OtpErlangString;
 import com.ericsson.otp.erlang.OtpErlangTuple;
-
+import com.ericsson.otp.erlang.OtpErlangAtom;
+import com.ericsson.otp.erlang.OtpErlangList;
+import com.ericsson.otp.erlang.OtpErlangString;
+import com.ericsson.otp.erlang.OtpErlangMap;
 import erlyberly.node.OtpUtil;
 
-public class ErlangFormatter implements TermFormatter {
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Iterator;
+import java.nio.charset.StandardCharsets;
+
+public class ElixirFormatter implements TermFormatter {
 
     @Override
     public StringBuilder appendToString(OtpErlangObject obj, StringBuilder sb) {
         if(obj instanceof OtpErlangBinary) {
-            sb.append("<<");
-            Formatting.binaryToString((OtpErlangBinary) obj, ", ", sb);
-            sb.append(">>");
+            OtpErlangBinary bin = (OtpErlangBinary) obj;
+            if (Formatting.isDisplayableString(bin)) {
+                sb.append("\"");
+                sb.append(new String(bin.binaryValue(), StandardCharsets.UTF_8));
+                sb.append("\"");
+            } else {
+                sb.append("<<");
+                Formatting.binaryToString(bin, ", ", sb);
+                sb.append(">>");
+            }
         }
         else if(obj instanceof OtpErlangPid) {
             sb.append(pidToString((OtpErlangPid) obj));
@@ -79,7 +89,31 @@ public class ErlangFormatter implements TermFormatter {
             sb.append(brackets.charAt(1));
         }
         else if(obj instanceof OtpErlangString) {
-            Formatting.appendString((OtpErlangString) obj, this, "\"", sb);
+            Formatting.appendString((OtpErlangString) obj, this, "\'", sb);
+        }
+        else if(obj instanceof OtpErlangAtom){
+            sb.append(":");
+            sb.append(obj.toString());
+        }
+        else if(obj instanceof OtpErlangMap) {
+            sb.append("%{");
+            Iterator<Map.Entry<OtpErlangObject,OtpErlangObject>> elemIt = ((OtpErlangMap) obj).entrySet().iterator();
+            while(elemIt.hasNext()) {
+                Map.Entry<OtpErlangObject,OtpErlangObject> elem = elemIt.next();
+                if (elem.getKey() instanceof OtpErlangAtom) {
+                    sb.append(elem.getKey().toString());
+                    sb.append(": ");
+                }
+                else {
+                    appendToString(elem.getKey(), sb);
+                    sb.append(" => ");
+                }
+                appendToString(elem.getValue(), sb);
+                if (elemIt.hasNext()) {
+                    sb.append(", ");
+                }
+            }
+            sb.append("}");
         }
         else {
             sb.append(obj.toString());
@@ -110,9 +144,9 @@ public class ErlangFormatter implements TermFormatter {
     @Override
     public String modFuncArgsToString(OtpErlangTuple mfa) {
         StringBuilder sb = new StringBuilder();
-        sb.append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(0)))
-          .append(":")
-          .append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(1)))
+        sb.append(moduleNameToString((OtpErlangAtom) mfa.elementAt(0)))
+          .append(".")
+          .append(funToStringNoQuotes((OtpErlangAtom) mfa.elementAt(1)))
           .append("(");
         OtpErlangList args = (OtpErlangList) mfa.elementAt(2);
         ArrayList<String> stringArgs = new ArrayList<>();
@@ -124,17 +158,28 @@ public class ErlangFormatter implements TermFormatter {
         return sb.toString();
     }
 
-    private String atomToStringNoQuotes(OtpErlangAtom atom) {
+    private String moduleNameToString(OtpErlangAtom mod) {
+        String str = mod.atomValue();
+        if(str.startsWith("Elixir."))
+            return str.substring(7);
+        else
+            return ":" + mod.atomValue();
+    }
+
+    private String funToStringNoQuotes(OtpErlangAtom atom) {
         return atom.atomValue();
+    }
+    private String atomToStringNoQuotes(OtpErlangAtom atom) {
+        return ":" + atom.atomValue();
     }
 
     @Override
     public String modFuncArityToString(OtpErlangTuple mfa) {
         StringBuilder sb = new StringBuilder();
         OtpErlangList argsList = OtpUtil.toErlangList(mfa.elementAt(2));
-        sb.append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(0)))
-          .append(":")
-          .append(atomToStringNoQuotes((OtpErlangAtom) mfa.elementAt(1)))
+        sb.append(moduleNameToString((OtpErlangAtom) mfa.elementAt(0)))
+          .append(".")
+          .append(funToStringNoQuotes((OtpErlangAtom) mfa.elementAt(1)))
           .append("/").append(argsList.arity());
         return sb.toString();
     }

--- a/src/main/java/erlyberly/format/Formatting.java
+++ b/src/main/java/erlyberly/format/Formatting.java
@@ -109,6 +109,9 @@ class Formatting {
         return b > 31 && b < 127;
     }
 
+    /**
+     * Make a guess if the given binary is a UTF-8 string or not.
+     */
     public static boolean isDisplayableString(OtpErlangBinary bin) {
         int expected;
         byte[] bytes = bin.binaryValue();

--- a/src/main/java/erlyberly/format/Formatting.java
+++ b/src/main/java/erlyberly/format/Formatting.java
@@ -27,13 +27,13 @@ class Formatting {
 
     private Formatting() {}
 
-    public static void appendString(OtpErlangString aString, TermFormatter formatter, StringBuilder sb) {
+    public static void appendString(OtpErlangString aString, TermFormatter formatter, String quote, StringBuilder sb) {
         String stringValue = aString.stringValue();
         // sometimes a list of integers can be mis-typed by jinterface as a string
         // in this case we format it ourselves as a list of ints
         boolean isString = isString(stringValue);
         if(isString) {
-            sb.append("\"").append(stringValue.replace("\n", "\\n")).append("\"");
+            sb.append(quote).append(stringValue.replace("\n", "\\n")).append(quote);
         }
         else {
             appendListOfInts(stringValue, formatter, sb);
@@ -107,5 +107,26 @@ class Formatting {
 
     private static boolean isDisplayableChar(int b) {
         return b > 31 && b < 127;
+    }
+
+    public static boolean isDisplayableString(OtpErlangBinary bin) {
+        int expected;
+        byte[] bytes = bin.binaryValue();
+        for (int i = 0; i < bytes.length; i++) {
+            int ch = bytes[i];
+            if (isDisplayableChar(ch)) continue;
+            else if ((ch & 0b11100000) == 0b11000000) expected = 1;
+            else if ((ch & 0b11110000) == 0b11100000) expected = 2;
+            else if ((ch & 0b11111000) == 0b11100000) expected = 3;
+            else return false;
+
+            while (expected > 0) {
+                if (i + expected >= bytes.length) return false;
+                if ((bytes[i + 1] & 0b11000000) != 0b10000000) return false;
+                expected--;
+                i++;
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/erlyberly/format/LFEFormatter.java
+++ b/src/main/java/erlyberly/format/LFEFormatter.java
@@ -100,7 +100,7 @@ public class LFEFormatter implements TermFormatter {
             sb.append(")");
         }
         else if(obj instanceof OtpErlangString) {
-            Formatting.appendString((OtpErlangString) obj, this, sb);
+            Formatting.appendString((OtpErlangString) obj, this, "\"", sb);
         }
         else {
             sb.append(obj.toString());

--- a/src/main/resources/erlyberly/preferences.fxml
+++ b/src/main/resources/erlyberly/preferences.fxml
@@ -31,10 +31,12 @@
       <CheckBox fx:id="showSourceInSystemEditorBox" text="Show Source in the System Text Editor"
         GridPane.columnSpan="2" GridPane.rowIndex="5" />
       <Separator GridPane.columnSpan="2" GridPane.rowIndex="6" />
-      <RadioButton fx:id="erlangTermsButton" text="Display Erlang Terms"
+     <RadioButton fx:id="erlangTermsButton" text="Display Erlang Terms"
         GridPane.columnSpan="2" GridPane.rowIndex="7" />
-      <RadioButton fx:id="lfeTermsButton" text="Display LFE Terms"
+     <RadioButton fx:id="elixirTermsButton" text="Display Elixir Terms"
         GridPane.columnSpan="2" GridPane.rowIndex="8" />
+      <RadioButton fx:id="lfeTermsButton" text="Display LFE Terms"
+        GridPane.columnSpan="2" GridPane.rowIndex="9" />
    </children>
    <padding>
       <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />


### PR DESCRIPTION
Elixir support arrived! :) At least the first version.

The following is displayed in the trace window:

<img width="742" alt="screen shot 2017-01-11 at 22 44 07" src="https://cloud.githubusercontent.com/assets/1858479/21869072/173725c0-d856-11e6-8b8c-f09dbbc43f57.png">

while tracing Application.put_env/3 when running the following in IEx:
---------------------------------------------------------------------

iex(my@localhost)80> Application.put_env :an, :elixir_string, "Elixir string"
:ok
iex(my@localhost)81> Application.put_env :an, :erlang_string, 'erlang string'
:ok
iex(my@localhost)82> Application.put_env :an, :atom, :hello_atom
:ok
iex(my@localhost)83> Application.put_env :a, :list, [1,2,3]
:ok
iex(my@localhost)84> Application.put_env :a, :binary, <<1,2,3>>
:ok
iex(my@localhost)85> Application.put_env :a, :tuple, {1,2}
:ok
iex(my@localhost)86> Application.put_env :a, :map, %{foo: "bar"}
:ok
iex(my@localhost)87> Application.put_env :a, :map, %{"hello" => "world", a: 1, b: 2}
:ok
iex(my@localhost)88> Application.put_env :a, :map, %{"hello" => %{inline: "map"}, a: 1, b: 2}
:ok 

Fixes #94.