### PR TITLE
Allow traces to be toggled through the trace log

### DIFF
--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -178,7 +178,7 @@ public class DbgTraceView extends VBox {
     }
 
     private void putTraceContextMenu() {
-        TraceContextMenu traceContextMenu = new TraceContextMenu();
+        TraceContextMenu traceContextMenu = new TraceContextMenu(dbgController);
         traceContextMenu.setItems(dbgController.getTraceLogs());
         traceContextMenu
                 .setSelectedItems(tracesBox.getSelectionModel().getSelectedItems());

--- a/src/main/java/erlyberly/TraceContextMenu.java
+++ b/src/main/java/erlyberly/TraceContextMenu.java
@@ -32,15 +32,19 @@ import javafx.scene.input.KeyCombination;
 
 public class TraceContextMenu extends ContextMenu {
 
+    private final DbgController dbgController;
+
     private ObservableList<TraceLog> items, selectedItems;
 
-    public TraceContextMenu() {
+    public TraceContextMenu(DbgController aDbgContoller) {
+        dbgController = aDbgContoller;
         getItems().add(menuItem("Copy All", "shortcut+c", this::onCopy));
         getItems().add(menuItem("Copy Function Call", null, this::onCopyCalls));
         getItems().add(new SeparatorMenuItem());
         getItems().add(menuItem("Delete", "delete", this::onDelete));
         getItems().add(menuItem("Delete All", "shortcut+n", this::onDeleteAll));
         getItems().add(menuItem("Add Breaker", "shortcut+b", this::onAddBreaker));
+        getItems().add(menuItem("Toggle Trace", null, this::onTraceToggle));
     }
 
     private MenuItem menuItem(String text, String accelerator, EventHandler<ActionEvent> e) {
@@ -81,6 +85,12 @@ public class TraceContextMenu extends ContextMenu {
 
         content.putString(sbuilder.toString());
         clipboard.setContent(content);
+    }
+
+    private void onTraceToggle(ActionEvent e) {
+        for (TraceLog log : selectedItems) {
+        	dbgController.toggleTraceModFunc(log.getModFunc());
+        }
     }
 
     private void onDelete(ActionEvent e) {

--- a/src/main/java/erlyberly/TraceContextMenu.java
+++ b/src/main/java/erlyberly/TraceContextMenu.java
@@ -89,7 +89,7 @@ public class TraceContextMenu extends ContextMenu {
 
     private void onTraceToggle(ActionEvent e) {
         for (TraceLog log : selectedItems) {
-        	dbgController.toggleTraceModFunc(log.getModFunc());
+            dbgController.toggleTraceModFunc(log.getModFunc());
         }
     }
 

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -37,7 +37,8 @@ import javafx.beans.property.SimpleStringProperty;
 
 public class TraceLog implements Comparable<TraceLog> {
 
-    public static final OtpErlangAtom EXCEPTION_FROM_ATOM = new OtpErlangAtom("exception_from");
+    private static final OtpErlangAtom FN_ATOM = new OtpErlangAtom("fn");
+	public static final OtpErlangAtom EXCEPTION_FROM_ATOM = new OtpErlangAtom("exception_from");
     public static final OtpErlangAtom RESULT_ATOM = new OtpErlangAtom("result");
     public static final OtpErlangAtom ATOM_PID = new OtpErlangAtom("pid");
     public static final OtpErlangAtom ATOM_REG_NAME = new OtpErlangAtom("reg_name");
@@ -162,8 +163,11 @@ public class TraceLog implements Comparable<TraceLog> {
         return ((OtpErlangLong)tsReturn).longValue() - ((OtpErlangLong)tsCall).longValue();
     }
 
+	/**
+	 * Returns an MFA. 
+	 */
     private OtpErlangTuple getFunctionFromMap() {
-        return (OtpErlangTuple)map.get(new OtpErlangAtom("fn"));
+        return (OtpErlangTuple)map.get(FN_ATOM);
     }
 
     public boolean isExceptionThrower() {
@@ -321,4 +325,12 @@ public class TraceLog implements Comparable<TraceLog> {
             stacktrace = new OtpErlangList();
         return stacktrace;
     }
+
+	public ModFunc getModFunc() {
+		OtpErlangTuple mfa = getFunctionFromMap();
+		OtpErlangAtom module = (OtpErlangAtom) mfa.elementAt(0);
+		OtpErlangAtom function = (OtpErlangAtom) mfa.elementAt(1);
+		int arity = ((OtpErlangList) mfa.elementAt(2)).arity();
+		return new ModFunc(module.atomValue(), function.atomValue(), arity, false, false);
+	}
 }

--- a/src/main/java/erlyberly/TraceLog.java
+++ b/src/main/java/erlyberly/TraceLog.java
@@ -38,7 +38,7 @@ import javafx.beans.property.SimpleStringProperty;
 public class TraceLog implements Comparable<TraceLog> {
 
     private static final OtpErlangAtom FN_ATOM = new OtpErlangAtom("fn");
-	public static final OtpErlangAtom EXCEPTION_FROM_ATOM = new OtpErlangAtom("exception_from");
+    public static final OtpErlangAtom EXCEPTION_FROM_ATOM = new OtpErlangAtom("exception_from");
     public static final OtpErlangAtom RESULT_ATOM = new OtpErlangAtom("result");
     public static final OtpErlangAtom ATOM_PID = new OtpErlangAtom("pid");
     public static final OtpErlangAtom ATOM_REG_NAME = new OtpErlangAtom("reg_name");
@@ -163,9 +163,9 @@ public class TraceLog implements Comparable<TraceLog> {
         return ((OtpErlangLong)tsReturn).longValue() - ((OtpErlangLong)tsCall).longValue();
     }
 
-	/**
-	 * Returns an MFA. 
-	 */
+    /**
+     * Returns an MFA.
+     */
     private OtpErlangTuple getFunctionFromMap() {
         return (OtpErlangTuple)map.get(FN_ATOM);
     }
@@ -326,11 +326,11 @@ public class TraceLog implements Comparable<TraceLog> {
         return stacktrace;
     }
 
-	public ModFunc getModFunc() {
-		OtpErlangTuple mfa = getFunctionFromMap();
-		OtpErlangAtom module = (OtpErlangAtom) mfa.elementAt(0);
-		OtpErlangAtom function = (OtpErlangAtom) mfa.elementAt(1);
-		int arity = ((OtpErlangList) mfa.elementAt(2)).arity();
-		return new ModFunc(module.atomValue(), function.atomValue(), arity, false, false);
-	}
+    public ModFunc getModFunc() {
+        OtpErlangTuple mfa = getFunctionFromMap();
+        OtpErlangAtom module = (OtpErlangAtom) mfa.elementAt(0);
+        OtpErlangAtom function = (OtpErlangAtom) mfa.elementAt(1);
+        int arity = ((OtpErlangList) mfa.elementAt(2)).arity();
+        return new ModFunc(module.atomValue(), function.atomValue(), arity, false, false);
+    }
 }


### PR DESCRIPTION
When debugging, I often put lots of traces down, then narrow the number of traces as I home in on the bug. This change will allow traces to be toggled by right clicking on a trace, and then selecting the `Toggle Trace` option. This can be used to reapply a trace that has been removed.

![image](https://cloud.githubusercontent.com/assets/213455/24103131/33f2dc72-0d76-11e7-9a74-1ab43a816cf3.png)
