### PR TITLE
Add Maps support for TermTreeView

### DIFF
--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -18,6 +18,7 @@
 package erlyberly;
 
 import java.io.IOException;
+import java.util.Map;
 
 import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangBinary;
@@ -26,6 +27,7 @@ import com.ericsson.otp.erlang.OtpErlangFun;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangTuple;
+import com.ericsson.otp.erlang.OtpErlangMap;
 
 import erlyberly.format.TermFormatter;
 import erlyberly.node.OtpUtil;
@@ -217,6 +219,28 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                     parent.getChildren().add(new TreeItem<>(new TermTreeItem(obj, f.listRightParen())));
                 }
             }
+        }
+        else if (obj instanceof OtpErlangMap){
+            TreeItem<TermTreeItem> mapNode = new TreeItem<>(new TermTreeItem(obj, f.mapLeft(obj)));
+            parent.getChildren().add(mapNode);
+            for (Map.Entry<OtpErlangObject,OtpErlangObject> e : ((OtpErlangMap) obj).entrySet()) {
+                if (f.isHiddenField(e.getKey()))
+                    continue;
+                String keyStr = f.mapKeyToString(e.getKey());
+                String valStr = f.toString(e.getValue());
+                if (valStr.length() < 50) {
+                    TreeItem<TermTreeItem> key = new TreeItem<>(new TermTreeItem(e.getKey(), valStr));
+                    key.setGraphic(recordLabel(keyStr));
+                    mapNode.getChildren().add(key);
+                }
+                else {
+                    TreeItem<TermTreeItem> key = new TreeItem<>(new TermTreeItem(e.getKey(), ""));
+                    key.setGraphic(recordLabel(keyStr));
+                    addToTreeItem(key, e.getValue());
+                    mapNode.getChildren().add(key);
+                }
+            }
+            parent.getChildren().add(new TreeItem<>(new TermTreeItem(obj, f.mapRight())));
         }
         else {
             parent.getChildren().add(new TreeItem<>(new TermTreeItem(obj, f.toString(obj))));

--- a/src/main/java/erlyberly/format/ElixirFormatter.java
+++ b/src/main/java/erlyberly/format/ElixirFormatter.java
@@ -124,19 +124,14 @@ public class ElixirFormatter implements TermFormatter {
         }
         else if(obj instanceof OtpErlangMap) {
             OtpErlangMap map = (OtpErlangMap) obj;
-            OtpErlangAtom structNameKey = new OtpErlangAtom(STRUCT_KEY);
-            if (map.get(structNameKey) != null) {
-                String structName = stripElixirPrefix(map.get(structNameKey).toString());
-                sb.append("%" + structName + "{");
-                map.remove(structNameKey);
-            }
-            else {
-                sb.append("%{");
-            }
+            sb.append(mapLeft(obj));
             Iterator<Map.Entry<OtpErlangObject,OtpErlangObject>> elemIt = map.entrySet().iterator();
             while(elemIt.hasNext()) {
                 Map.Entry<OtpErlangObject,OtpErlangObject> elem = elemIt.next();
                 if (elem.getKey() instanceof OtpErlangAtom) {
+                    if (isHiddenField(elem.getKey())) {
+                        continue;
+                    }
                     sb.append(elem.getKey().toString());
                     sb.append(": ");
                 }
@@ -155,6 +150,16 @@ public class ElixirFormatter implements TermFormatter {
             sb.append(obj.toString());
         }
         return sb;
+    }
+
+    @Override
+    public  String mapKeyToString(OtpErlangObject obj) {
+        if (obj instanceof OtpErlangAtom) {
+            return obj.toString() + ": ";
+        }
+        else {
+            return appendToString(obj, new StringBuilder()).toString() + " => ";
+        }
     }
 
     private static String pidToString(OtpErlangPid pid) {
@@ -263,6 +268,29 @@ public class ElixirFormatter implements TermFormatter {
     @Override
     public String listRightParen() {
         return "]";
+    }
+
+    @Override
+    public String mapLeft(OtpErlangObject obj)
+    {
+        OtpErlangMap map = (OtpErlangMap) obj;
+        OtpErlangAtom structNameKey = new OtpErlangAtom(STRUCT_KEY);
+        if (map.get(structNameKey) != null) {
+            String structName = stripElixirPrefix(map.get(structNameKey).toString());
+            return "%" + structName + "{";
+        }
+        return "%{";
+    }
+
+    @Override
+    public Boolean isHiddenField(OtpErlangObject key) {
+        OtpErlangAtom structNameKey = new OtpErlangAtom(STRUCT_KEY);
+        return (key instanceof OtpErlangAtom) && key.equals(structNameKey);
+    }
+
+    @Override
+    public String mapRight() {
+        return "}";
     }
 
     @Override

--- a/src/main/java/erlyberly/format/ErlangFormatter.java
+++ b/src/main/java/erlyberly/format/ErlangFormatter.java
@@ -175,6 +175,18 @@ public class ErlangFormatter implements TermFormatter {
     }
 
     @Override
+    public String mapLeft(OtpErlangObject obj) {
+        return "#{";
+    }
+
+    @Override
+    public Boolean isHiddenField(OtpErlangObject key) {return false;}
+
+    @Override
+    public String mapRight() {
+        return "}";
+    }
+    @Override
     public String cons() {
         return "|";
     }

--- a/src/main/java/erlyberly/format/LFEFormatter.java
+++ b/src/main/java/erlyberly/format/LFEFormatter.java
@@ -148,6 +148,19 @@ public class LFEFormatter implements TermFormatter {
     }
 
     @Override
+    public String mapLeft(OtpErlangObject obj) {
+        return "#M(";
+    }
+
+    @Override
+    public String mapRight() {
+        return ")";
+    }
+
+    @Override
+    public Boolean isHiddenField(OtpErlangObject key) {return false;}
+
+    @Override
     public String cons() {
         return ".";
     }

--- a/src/main/java/erlyberly/format/TermFormatter.java
+++ b/src/main/java/erlyberly/format/TermFormatter.java
@@ -43,6 +43,10 @@ public interface TermFormatter {
         return appendToString(obj, new StringBuilder()).toString();
     }
 
+    default String mapKeyToString(OtpErlangObject obj) {
+        return toString(obj) + " => ";
+    }
+
     String emptyTupleString();
 
     String tupleLeftParen();
@@ -54,6 +58,13 @@ public interface TermFormatter {
     String listLeftParen();
 
     String listRightParen();
+
+    String mapLeft(OtpErlangObject obj);
+
+    String mapRight();
+
+    // True if given key in map should be hidden (Elixir __struct__)
+    Boolean isHiddenField(OtpErlangObject key);
 
     String cons();
 }


### PR DESCRIPTION
Display maps as part of the foldable tree in TermTreeView.

TermTreeView can also display Elixir structs now, which are Erlang maps
with a special field denoting the name of the struct. The meta field is
hidden and the name of the struct is displayed.

Elixir syntax showing a Struct unfolded (default):
![screen shot 2017-03-25 at 20 41 22](https://cloud.githubusercontent.com/assets/1858479/24325648/720fac8a-119d-11e7-84c2-aa9dc606c74d.png)

Elixir syntax:
![screen shot 2017-03-25 at 20 41 49](https://cloud.githubusercontent.com/assets/1858479/24325637/301e185c-119d-11e7-83a9-346201fbaafc.png)

Erlang syntax:
![screen shot 2017-03-25 at 20 42 32](https://cloud.githubusercontent.com/assets/1858479/24325633/20ee130a-119d-11e7-807e-6ed232288fb9.png)

LFE syntax:
![screen shot 2017-03-25 at 20 52 25](https://cloud.githubusercontent.com/assets/1858479/24325641/3632ffc8-119d-11e7-821f-6d977494047f.png)
