### PR TITLE
Fix Elixir atoms missing colon prefix

### DIFF
--- a/src/main/java/erlyberly/format/ElixirFormatter.java
+++ b/src/main/java/erlyberly/format/ElixirFormatter.java
@@ -119,6 +119,10 @@ public class ElixirFormatter implements TermFormatter {
                     // Convert Erlang style escaped atoms to Elixir style
                     str = ":\"" + innerStr +"\"";
                 }
+
+            }
+            else {
+                str = ":" + str;
             }
             sb.append(str);
         }


### PR DESCRIPTION
There are 3 cases:
  - :atom
  - :"Any char atom without Elixir prefix"
  - Atom (type or module name, no colon prefix)

![screen shot 2017-03-25 at 22 00 54](https://cloud.githubusercontent.com/assets/1858479/24326066/9ea95c60-11a6-11e7-858e-dadfb3fcea25.png)
