### PR TITLE
Remember used nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.github.andytill</groupId>
       <artifactId>floaty-field</artifactId>
-      <version>1.0.1</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.andytill</groupId>
@@ -103,6 +103,7 @@
           </archive>
         </configuration>
       </plugin>     
+  
       <plugin>
        <groupId>org.apache.maven.plugins</groupId>
        <artifactId>maven-checkstyle-plugin</artifactId>
@@ -125,17 +126,15 @@
        </executions>
      </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-      </plugin>
+
 
   <plugin>
     <artifactId>exec-maven-plugin</artifactId>
     <groupId>org.codehaus.mojo</groupId>
+    <version>1.6.0</version>
     <executions>
-      <execution><!-- Run our version calculation script -->
+      <execution>
+      <!-- Run our version calculation script -->
         <id>Version Calculation</id>
         <phase>compile</phase>
         <goals>

--- a/src/main/java/erlyberly/ConnectionView.java
+++ b/src/main/java/erlyberly/ConnectionView.java
@@ -18,46 +18,108 @@
 package erlyberly;
 
 import java.io.IOException;
-import java.net.URL;
-import java.util.ResourceBundle;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.ericsson.otp.erlang.OtpAuthException;
 import com.ericsson.otp.erlang.OtpErlangException;
 
 import de.jensd.fx.fontawesome.AwesomeIcon;
+import floatyfield.FloatyFieldControl;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.fxml.FXML;
-import javafx.fxml.Initializable;
+import javafx.event.ActionEvent;
+import javafx.geometry.Insets;
 import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
 import javafx.scene.control.Label;
-import javafx.scene.control.TextField;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.Separator;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import ui.FAIcon;
 
 /**
  * Connection details control to connect to the remote node.
  */
-public class ConnectionView implements Initializable {
+public class ConnectionView extends VBox {
 
     private final SimpleBooleanProperty isConnecting = new SimpleBooleanProperty();
 
-    @FXML
-    private TextField nodeNameField;
-    @FXML
-    private TextField cookieField;
-    @FXML
-    private Button connectButton;
-    @FXML
+    private FloatyFieldControl nodeNameField;
+    private FloatyFieldControl cookieField;
+    private final Button connectButton;
     private Label messageLabel;
-    @FXML
-    private CheckBox autoConnectField;
+    // private CheckBox autoConnectField;
+    private final TableView<KnownNode> knownNodesTable;
 
-    @Override
-    public void initialize(URL url, ResourceBundle r) {
-        PrefBind.bind("targetNodeName", nodeNameField.textProperty());
-        PrefBind.bind("cookieName", cookieField.textProperty());
+    private RadioButton newNodeRadioButton;
+
+    private RadioButton knownRadioButton;
+
+    @SuppressWarnings("unchecked")
+    public ConnectionView() {
+        setSpacing(10d);
+        setPadding(new Insets(10, 10, 10, 10));
+
+        ToggleGroup group = new ToggleGroup();
+        newNodeRadioButton = new RadioButton("New node");
+        knownRadioButton = new RadioButton("Known nodes");
+        // TODO put some style on these radio buttons so that they look like section headers
+        newNodeRadioButton.setToggleGroup(group);
+        knownRadioButton.setToggleGroup(group);
+        newNodeRadioButton.setSelected(true);
+
+        nodeNameField = new FloatyFieldControl();
+        nodeNameField.getModel().promptTextProperty().set("Node Name");
+        nodeNameField.getModel().getField().focusedProperty().addListener((o, oldv, newv) -> {
+            if(newv) {
+                newNodeRadioButton.setSelected(true);
+            }
+        });
+        cookieField = new FloatyFieldControl();
+        cookieField.getModel().promptTextProperty().set("Cookie");
+        cookieField.getModel().getField().focusedProperty().addListener((o, oldv, newv) -> {
+            if(newv) {
+                newNodeRadioButton.setSelected(true);
+            }
+        });
+
+        knownNodesTable = new TableView<>();
+        VBox.setVgrow(knownNodesTable, Priority.SOMETIMES);
+        knownNodesTable.getColumns().setAll(
+            newColumn("Node Name", "nodeName"),
+            newColumn("Cookie", "cookie")
+        );
+        knownNodesTable.getSelectionModel().selectedItemProperty().addListener(
+            (o, oldv, newv) -> {
+                if(newv != null) {
+                    knownRadioButton.setSelected(true);
+                }
+            });
+        knownNodesTable.getItems().addAll(knownNodesConfigToRowObjects(PrefBind.getKnownNodes()));
+
+        // button width across the whole scene
+        final double connectButtonHeight = 42d;
+        connectButton = new Button("Connect");
+        connectButton.setPrefWidth(1000d);
+        connectButton.setPrefHeight(connectButtonHeight);
+        connectButton.setMinHeight(connectButtonHeight);
+        connectButton.setOnAction(this::onConnectButtonPressed);
+
+        getChildren().addAll(
+            newNodeRadioButton,
+            nodeNameField, new Separator(),
+            cookieField, new Separator(),
+            knownRadioButton,
+            knownNodesTable,
+            connectButton);
+
+/*
         PrefBind.bindBoolean("autoConnect", autoConnectField.selectedProperty());
 
         nodeNameField.disableProperty().bind(isConnecting);
@@ -76,21 +138,63 @@ public class ConnectionView implements Initializable {
             }
 
             this.onConnect();
-        }else{
+        }
+        else {
             // show the Connection Dialogue...
+        }*/
+    }
+
+    private List<KnownNode> knownNodesConfigToRowObjects(List<List<String>> knownNodeStrings) {
+        ArrayList<KnownNode> knownNodeRows = new ArrayList<>();
+        for (List<String> confStrings : knownNodeStrings) {
+            knownNodeRows.add(
+                new KnownNode(confStrings.get(0), confStrings.get(1))
+            );
+        }
+        return knownNodeRows;
+    }
+
+    private TableColumn<KnownNode, String> newColumn(String colText, String colPropertyName) {
+        TableColumn<KnownNode, String> column;
+        column = new TableColumn<>(colText);
+        column.setCellValueFactory(new PropertyValueFactory<KnownNode, String>(colPropertyName));
+        return column;
+    }
+
+    private void onConnectButtonPressed(ActionEvent e) {
+        String cookie, nodeName;
+        if(newNodeRadioButton.isSelected()) {
+            nodeName = nodeNameField.getModel().getText();
+            cookie = removeApostrophesFromCookie(cookieField.getModel().getText());
+            if(nodeName == null || "".equals(nodeName))
+                return;
+            maybeStoreNodeInfoInConfig(nodeName, cookie);
+            connectToRemoteNode(cookie, nodeName);
+        }
+        else if(knownRadioButton.isSelected()) {
+            KnownNode knownNode = knownNodesTable.getSelectionModel().getSelectedItem();
+            if(knownNode == null)
+                return;
+            nodeName = knownNode.getNodeName();
+            cookie = removeApostrophesFromCookie(knownNode.getCookie());
+            connectToRemoteNode(cookie, nodeName);
         }
     }
 
-    @FXML
-    public void onConnect() {
-        String cookie;
+    private void maybeStoreNodeInfoInConfig(String nodeName, String cookie) {
+       KnownNode knownNode = new KnownNode(nodeName, cookie);
+       if(!knownNodesTable.getItems().contains(knownNode)) {
+           PrefBind.storeKnownNode(knownNode);
+       }
+    }
 
-        cookie = cookieField.getText();
-        cookie = cookie.replaceAll("'", "");
-
+    private void connectToRemoteNode(String cookie, String nodeName) {
         isConnecting.set(true);
+        new ConnectorThead(nodeName, cookie).start();
+    }
 
-        new ConnectorThead(nodeNameField.getText(), cookie).start();
+    private String removeApostrophesFromCookie(String cookie) {
+        return cookie.replaceAll("'", "");
     }
 
     private void connectionFailed(String message) {
@@ -143,6 +247,54 @@ public class ConnectionView implements Initializable {
             catch (OtpErlangException | OtpAuthException | IOException e) {
                 Platform.runLater(() -> { connectionFailed(e.getMessage()); });
             }
+        }
+    }
+
+    /**
+     * Type for table rows. Public because of restrictions using reflection.
+     */
+    public static class KnownNode {
+        private final String nodeName, cookie;
+        public KnownNode(String nodeName, String cookie) {
+            assert nodeName != null;
+            assert !"".equals(nodeName);
+            this.nodeName = nodeName;
+            this.cookie = cookie;
+        }
+        public String getNodeName() {
+            return nodeName;
+        }
+        public String getCookie() {
+            return cookie;
+        }
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((cookie == null) ? 0 : cookie.hashCode());
+            result = prime * result + ((nodeName == null) ? 0 : nodeName.hashCode());
+            return result;
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            KnownNode other = (KnownNode) obj;
+            if (cookie == null) {
+                if (other.cookie != null)
+                    return false;
+            } else if (!cookie.equals(other.cookie))
+                return false;
+            if (nodeName == null) {
+                if (other.nodeName != null)
+                    return false;
+            } else if (!nodeName.equals(other.nodeName))
+                return false;
+            return true;
         }
     }
 }

--- a/src/main/java/erlyberly/ConnectionView.java
+++ b/src/main/java/erlyberly/ConnectionView.java
@@ -52,6 +52,7 @@ import ui.FAIcon;
 /**
  * Connection details control to connect to the remote node.
  */
+@SuppressWarnings({ "unchecked", "restriction" })
 public class ConnectionView extends VBox {
 
     private final SimpleBooleanProperty isConnecting = new SimpleBooleanProperty();
@@ -76,7 +77,6 @@ public class ConnectionView extends VBox {
 
     private FilteredList<KnownNode> filteredRows;
 
-    @SuppressWarnings("unchecked")
     public ConnectionView() {
         setSpacing(10d);
         setPadding(new Insets(10, 10, 10, 10));
@@ -88,7 +88,9 @@ public class ConnectionView extends VBox {
         newNodeRadioButton.setToggleGroup(group);
 
         knownRadioButton.setToggleGroup(group);
+        knownRadioButton.setMaxWidth(Double.MAX_VALUE);
         newNodeRadioButton.setSelected(true);
+        newNodeRadioButton.setMaxWidth(Double.MAX_VALUE);
 
         nodeNameField = new FloatyFieldControl();
         nodeNameField.getModel().promptTextProperty().set("Node Name");
@@ -113,7 +115,7 @@ public class ConnectionView extends VBox {
         knownNodesTable = new TableView<>();
         VBox.setVgrow(knownNodesTable, Priority.SOMETIMES);
         knownNodesTable.getColumns().setAll(
-            newColumn("Node Name", "nodeName"),
+            newColumn("Node Name", "nodeName", 250),
             newColumn("Cookie", "cookie")
         );
         knownNodesTable.getSelectionModel().selectedItemProperty().addListener(
@@ -135,21 +137,23 @@ public class ConnectionView extends VBox {
         connectButton.setOnAction(this::onConnectButtonPressed);
 
         getChildren().addAll(
-            newNodeRadioButton, new Separator(),
+            newNodeRadioButton, //new Separator(),
             nodeNameField, new Separator(),
-            cookieField, new Separator(),
+            cookieField, //new Separator(),
             knownRadioButton,
             new HBox(
                 filterField,
                 searchIcon()),
-            new Separator(),
+            //new Separator(),
             knownNodesTable,
             connectButton);
 
         newNodeRadioButton.disableProperty().bind(isConnecting);
+        newNodeRadioButton.getStyleClass().add("erlyberly-header");
         nodeNameField.getModel().getField().disableProperty().bind(isConnecting);
         cookieField.getModel().getField().disableProperty().bind(isConnecting);
         knownRadioButton.disableProperty().bind(isConnecting);
+        knownRadioButton.getStyleClass().add("erlyberly-header");
         filterField.getModel().getField().disableProperty().bind(isConnecting);
         knownNodesTable.disableProperty().bind(isConnecting);
         connectButton.disableProperty().bind(isConnecting.or(isNodeConnectable.not()));
@@ -179,6 +183,12 @@ public class ConnectionView extends VBox {
         else {
             // show the Connection Dialogue...
         }*/
+    }
+
+    private TableColumn<KnownNode, ?> newColumn(String colText, String colPropertyName, double colWidth) {
+        TableColumn<KnownNode, String> col = newColumn(colText, colPropertyName);
+        col.setPrefWidth(colWidth);
+        return col;
     }
 
     private FAIcon searchIcon() {

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -284,9 +284,9 @@ public class ErlyBerly extends Application {
 
         // javafx vertical resizing is laughably ugly, lets just disallow it
         //connectStage.setResizable(false);
-        connectStage.setWidth(600d);
-        connectStage.setHeight(600d);
-        connectStage.setTitle("Connect to Node");
+        connectStage.setWidth(800d);
+        connectStage.setHeight(400d);
+        connectStage.setTitle("Connect to Remote Node");
         // if the user closes the window without connecting then close the app
         connectStage.setOnCloseRequest((e) -> {
             if(!NODE_API.connectedProperty().get()) {

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -255,8 +255,8 @@ public class ErlyBerly extends Application {
 
         // javafx vertical resizing is laughably ugly, lets just disallow it
         //connectStage.setResizable(false);
-        connectStage.setWidth(400);
-        connectStage.setHeight(800d);
+        connectStage.setWidth(600d);
+        connectStage.setHeight(600d);
         connectStage.setTitle("Connect to Node");
         // if the user closes the window without connecting then close the app
         connectStage.setOnCloseRequest((e) -> {

--- a/src/main/java/erlyberly/ErlyBerly.java
+++ b/src/main/java/erlyberly/ErlyBerly.java
@@ -19,8 +19,8 @@ package erlyberly;
 
 import java.io.IOException;
 
-import erlyberly.format.ErlangFormatter;
 import erlyberly.format.ElixirFormatter;
+import erlyberly.format.ErlangFormatter;
 import erlyberly.format.LFEFormatter;
 import erlyberly.format.TermFormatter;
 import erlyberly.node.NodeAPI;
@@ -235,28 +235,36 @@ public class ErlyBerly extends Application {
     }
 
     private void displayConnectionPopup(Stage primaryStage) {
-        Stage connectStage;
+        Scene scene = new Scene(new ConnectionView());
 
+        // close the app when escape is pressed on the connection window
+        scene.setOnKeyPressed((e) -> {
+            if(e.getCode() == KeyCode.ESCAPE) {
+               Stage aStage = (Stage) scene.getWindow();
+               aStage.close();
+               primaryStage.close();
+            }
+        });
+        applyCssToWIndow(scene);
+
+        Stage connectStage;
         connectStage = new Stage();
         connectStage.initModality(Modality.WINDOW_MODAL);
-        connectStage.setScene(new Scene(new FxmlLoadable("/erlyberly/connection.fxml").load()));
+        connectStage.setScene(scene);
         connectStage.setAlwaysOnTop(true);
 
         // javafx vertical resizing is laughably ugly, lets just disallow it
-        connectStage.setResizable(false);
+        //connectStage.setResizable(false);
         connectStage.setWidth(400);
-
+        connectStage.setHeight(800d);
+        connectStage.setTitle("Connect to Node");
         // if the user closes the window without connecting then close the app
-        connectStage.setOnCloseRequest(new EventHandler<WindowEvent>() {
-            @Override
-            public void handle(WindowEvent e) {
-                if(!NODE_API.connectedProperty().get()) {
-                    Platform.exit();
-                }
-
-                Platform.runLater(() -> { primaryStage.setResizable(true); });
-            }});
-
+        connectStage.setOnCloseRequest((e) -> {
+            if(!NODE_API.connectedProperty().get()) {
+                Platform.exit();
+            }
+            Platform.runLater(() -> { primaryStage.setResizable(true); });
+        });
         connectStage.show();
     }
 

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -167,7 +167,7 @@ public class ModFuncContextMenu extends ContextMenu {
         List<String> defaultSkippedModules = Arrays.asList(
             "app_helper", "application", "binary", "code", "compile", "crypto", "dets", "dict", "erl_pp", "erl_syntax", "erlang", "ets", "exometer", "exometer_admin", "file", "gb_sets", "gen", "gen_event", "gen_fsm", "gen_server", "httpc", "httpd_util", "inet", "inet_parse", "inets", "io", "io_lib", "io_lib_pretty", "lager", "lager_config", "lists", "mnesia", "msgpack", "orddict", "proplists", "sets", "string", "timer"
         );
-        List<String> skippedModules = (List<String>) PrefBind.getOrDefault("xrefSkippedModules", defaultSkippedModules);
+        List<String> skippedModules = getConfiguredSkippedModuleNames(defaultSkippedModules);
         List<OtpErlangAtom> skippedModuleAtoms = skippedModules.stream().map(OtpUtil::atom).collect(Collectors.toList());
         try {
             OtpErlangObject callGraph = ErlyBerly.nodeAPI().callGraph(
@@ -182,6 +182,11 @@ public class ModFuncContextMenu extends ContextMenu {
         catch (OtpErlangException | IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> getConfiguredSkippedModuleNames(List<String> defaultSkippedModules) {
+        return (List<String>) PrefBind.getOrDefault("xrefSkippedModules", defaultSkippedModules);
     }
 
     private void onFunctionTrace(ActionEvent e) {

--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -21,6 +21,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -28,12 +31,13 @@ import java.util.TimerTask;
 import com.moandjiezana.toml.Toml;
 import com.moandjiezana.toml.TomlWriter;
 
+import erlyberly.ConnectionView.KnownNode;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
 
 /**
- * Load dot {@link Properties} files, bind them to JavaFX properties and auto-store
+ * Load dot Properties files, bind them to JavaFX properties and auto-store
  * them when the JavaFX properties change.
  * <p>
  * Call {@link PrefBind#setup()} before hand then {@link PrefBind#bind(String, StringProperty)} away.
@@ -146,5 +150,17 @@ public class PrefBind {
         synchronized (AWAIT_STORE_LOCK) {
             awaitingStore = true;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<List<String>> getKnownNodes() {
+        return (List<List<String>>) props.getOrDefault("knownNodes", new ArrayList<>());
+    }
+
+    public static void storeKnownNode(KnownNode knownNode) {
+        List<List<String>> knownNodes = getKnownNodes();
+        knownNodes.add(Arrays.asList(knownNode.getNodeName(), knownNode.getCookie()));
+        props.put("knownNodes", knownNodes);
+        store();
     }
 }

--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -164,6 +164,14 @@ public class PrefBind {
         store();
     }
 
+    public static void removeKnownNode(KnownNode knownNode) {
+        List<String> nodeAsList = Arrays.asList(knownNode.getNodeName(), knownNode.getCookie());
+        List<List<String>> knownNodes = getKnownNodes();
+        knownNodes.remove(nodeAsList);
+        props.put("knownNodes", knownNodes);
+        store();
+    }
+
     /**
      * The maximum number of traces that can be queued in the trace
      * proccesses queue before tracing is suspended on the node.

--- a/src/main/java/erlyberly/TopBarView.java
+++ b/src/main/java/erlyberly/TopBarView.java
@@ -30,7 +30,7 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import de.jensd.fx.fontawesome.AwesomeIcon;
 import erlyberly.node.AppProcs;
 import erlyberly.node.OtpUtil;
-import floatyfield.FloatyFieldView;
+import floatyfield.FloatyFieldControl;
 import javafx.application.Platform;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
@@ -217,10 +217,10 @@ public class TopBarView implements Initializable {
 
         erlangMemoryButton.setOnAction((e) -> { showErlangMemory(); });
 
-        FxmlLoadable loader = processCountStat();
+        FloatyFieldControl processCountField = processCountStat();
 
         topBox.getItems().add(new Separator(Orientation.VERTICAL));
-        topBox.getItems().add(loader.fxmlNode);
+        topBox.getItems().add(processCountField);
 
         // let's store the ui preferences, as the end user changes them...
         PrefBind.bindBoolean("hideProcesses", hideProcessesButton.selectedProperty());
@@ -384,33 +384,23 @@ public class TopBarView implements Initializable {
         });
     }
 
-    private FxmlLoadable processCountStat() {
-        FxmlLoadable loader = new FxmlLoadable("/floatyfield/floaty-field.fxml");
+    private FloatyFieldControl processCountStat() {
+        FloatyFieldControl floatyFieldControl;
+        floatyFieldControl = new FloatyFieldControl();
+        floatyFieldControl.getStyleClass().add("floaty-label");
+        floatyFieldControl.getModel().promptTextProperty().set("Processes");
+        floatyFieldControl.getModel().textProperty().set("0");
+        floatyFieldControl.getModel().disableProperty().set(true);
 
-        loader.load();
+        ErlyBerly.nodeAPI().appProcsProperty().addListener((o, ov, nv) -> { upateProcsStat(floatyFieldControl, nv); });
 
-        Parent fxmlNode;
-
-        fxmlNode = loader.fxmlNode;
-        fxmlNode.getStyleClass().add("floaty-label");
-
-        FloatyFieldView ffView;
-
-        ffView = (FloatyFieldView) loader.controller;
-        ffView.promptTextProperty().set("Processes");
-        ffView.textProperty().set("0");
-        ffView.disableProperty().set(true);
-
-        ErlyBerly.nodeAPI().appProcsProperty().addListener((o, ov, nv) -> { upateProcsStat(ffView, nv); });
-
-        return loader;
+        return floatyFieldControl;
     }
 
-    private void upateProcsStat(FloatyFieldView ffView, AppProcs nv) {
+    private void upateProcsStat(FloatyFieldControl floatyFieldControl, AppProcs nv) {
         String dateString = nv.getDateTime().format(DateTimeFormatter.ISO_TIME);
-
-        ffView.textProperty().set(Integer.toString(nv.getProcCount()));
-        ffView.promptTextProperty().set("Processes @ " + dateString);
+        floatyFieldControl.getModel().textProperty().set(Integer.toString(nv.getProcCount()));
+        floatyFieldControl.getModel().promptTextProperty().set("Processes @ " + dateString);
     }
 
     private ObservableMap<KeyCombination, Runnable> accelerators() {

--- a/src/main/resources/erlyberly/erlyberly.css
+++ b/src/main/resources/erlyberly/erlyberly.css
@@ -63,6 +63,26 @@
     -fx-text-fill: grey;
 }
 
+.erlyberly-header {
+/*    -fx-background-color: -fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, -fx-body-color;
+*/    -fx-padding: 5;
+-fx-size: 25;
+    -fx-border-style: solid;
+    -fx-border-color: 
+        /* 
+          Inner border: we have different colours along the top, right, bottom and left.
+          Refer to RT-12298 for the spec.
+        */
+        derive(-fx-base, 80%) 
+        linear-gradient(to bottom, derive(-fx-base,80%) 20%, derive(-fx-base,-10%) 90%)
+        derive(-fx-base, 10%) 
+        linear-gradient(to bottom, derive(-fx-base,80%) 20%, derive(-fx-base,-10%) 90%),
+        /* Outer border: */
+transparent #959595 #959595 transparent;
+-fx-background-color: -fx-body-color;
+
+}
+
 /*
  * used to show trace logs for functions that returned errors.
  */

--- a/src/main/resources/erlyberly/erlyberly.css
+++ b/src/main/resources/erlyberly/erlyberly.css
@@ -63,26 +63,6 @@
     -fx-text-fill: grey;
 }
 
-.erlyberly-header {
-/*    -fx-background-color: -fx-shadow-highlight-color, -fx-outer-border, -fx-inner-border, -fx-body-color;
-*/    -fx-padding: 5;
--fx-size: 25;
-    -fx-border-style: solid;
-    -fx-border-color: 
-        /* 
-          Inner border: we have different colours along the top, right, bottom and left.
-          Refer to RT-12298 for the spec.
-        */
-        derive(-fx-base, 80%) 
-        linear-gradient(to bottom, derive(-fx-base,80%) 20%, derive(-fx-base,-10%) 90%)
-        derive(-fx-base, 10%) 
-        linear-gradient(to bottom, derive(-fx-base,80%) 20%, derive(-fx-base,-10%) 90%),
-        /* Outer border: */
-transparent #959595 #959595 transparent;
--fx-background-color: -fx-body-color;
-
-}
-
 /*
  * used to show trace logs for functions that returned errors.
  */


### PR DESCRIPTION
Based on issue #74 "Recent Nodes Dropdown"

<img width="912" alt="screen shot 2017-12-27 at 19 30 53" src="https://user-images.githubusercontent.com/213455/34440248-d30d0a8e-ecab-11e7-8153-a3f5e79d1fda.png">

Remember nodes that have previously been connected to and show them in a table in the connection window.

Nodes can be deleted by selecting them and pressing the delete key, or right clicking and selecting it from the menu.

A new node can be input or modified by typing it's name into the node field and cookie field.