### PR TITLE
Miscellaneous Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
   <plugin>
     <artifactId>exec-maven-plugin</artifactId>
     <groupId>org.codehaus.mojo</groupId>
+    <version>1.6.0</version>
     <executions>
       <execution><!-- Run our version calculation script -->
         <id>Version Calculation</id>

--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -115,18 +115,13 @@ public class DbgController implements Initializable {
 
     private void traceModFunc(ModFunc function) {
         try {
-            ErlyBerly.nodeAPI().startTrace(function, getMaxTraceQueueLengthConfig());
+            ErlyBerly.nodeAPI().startTrace(function, PrefBind.getMaxTraceQueueLengthConfig());
 
             traces.add(function);
         }
         catch (Exception ex) {
             ex.printStackTrace();
         }
-    }
-
-    private int getMaxTraceQueueLengthConfig() {
-        Number maxTraceQueueLength = (Number) PrefBind.getOrDefault("maxTraceQueueLength", 1000);
-        return maxTraceQueueLength.intValue();
     }
 
     private void onRemoveTracer(ActionEvent e, ModFunc function) {
@@ -145,8 +140,9 @@ public class DbgController implements Initializable {
 
         for (ModFunc function : tracesCopy) {
             try {
-                ErlyBerly.nodeAPI().startTrace(function, getMaxTraceQueueLengthConfig());
-            } catch (Exception e) {
+                ErlyBerly.nodeAPI().startTrace(function, PrefBind.getMaxTraceQueueLengthConfig());
+            }
+            catch (Exception e) {
                 e.printStackTrace();
 
                 traces.remove(function);

--- a/src/main/java/erlyberly/DbgView.java
+++ b/src/main/java/erlyberly/DbgView.java
@@ -111,7 +111,7 @@ public class DbgView implements Initializable {
 
         sortedTreeModules.setComparator(treeItemModFuncComparator());
 
-        SplitPane.setResizableWithParent(modulesBox, Boolean.FALSE);
+        SplitPane.setResizableWithParent(modulesBox, Boolean.TRUE);
 
         ErlyBerly.nodeAPI().connectedProperty().addListener(this::onConnected);
 

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -175,6 +175,9 @@ public class ModFuncContextMenu extends ContextMenu {
                 OtpUtil.atom(func.getModuleName()),
                 OtpUtil.atom(func.getFuncName()),
                 new OtpErlangLong(func.getArity()));
+            if(!OtpUtil.isTupleTagged(NodeAPI.OK_ATOM, callGraph)) {
+                throw new RuntimeException(callGraph.toString());
+            }
             CallGraphView callGraphView = new CallGraphView(dbgController);
             callGraphView.callGraph((OtpErlangTuple) callGraph);
             ErlyBerly.showPane(func.toFullString() + " call graph", ErlyBerly.wrapInPane(callGraphView));

--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -147,4 +147,13 @@ public class PrefBind {
             awaitingStore = true;
         }
     }
+
+    /**
+     * The maximum number of traces that can be queued in the trace
+     * proccesses queue before tracing is suspended on the node.
+     */
+    public static int getMaxTraceQueueLengthConfig() {
+        Number maxTraceQueueLength = (Number)getOrDefault("maxTraceQueueLength", 1000);
+        return maxTraceQueueLength.intValue();
+    }
 }

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -89,7 +89,7 @@ public class NodeAPI {
 
     private static final OtpErlangAtom REX_ATOM = atom("rex");
 
-    private static final OtpErlangAtom OK_ATOM = atom("ok");
+    public static final OtpErlangAtom OK_ATOM = atom("ok");
 
     public interface RpcCallback<T> {
         void callback(T result);

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -89,6 +89,8 @@ public class NodeAPI {
 
     private static final OtpErlangAtom REX_ATOM = atom("rex");
 
+    private static final OtpErlangAtom OK_ATOM = atom("ok");
+
     public interface RpcCallback<T> {
         void callback(T result);
     }
@@ -267,10 +269,14 @@ public class NodeAPI {
     private synchronized void ensureDbgStarted() throws IOException, OtpErlangException {
         sendRPC(
             ERLYBERLY, "ensure_dbg_started",
-            list(tuple(atom(self.node()), mbox.self()))
+            list(tuple(atom(self.node()), mbox.self()), PrefBind.getMaxTraceQueueLengthConfig())
         );
-        // flush the return value
-        receiveRPC();
+        // the return should be {ok, TracerPid}
+        // we don't need to store the pid because it is registered
+        OtpErlangObject returnedObject = receiveRPC();
+        if(!OtpUtil.isTupleTagged(OK_ATOM, returnedObject)) {
+            throw new RuntimeException(returnedObject.toString());
+        }
     }
 
     private void loadModulesOnPath(String regex) throws IOException, OtpErlangException {

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -162,7 +162,9 @@ record_fields([]) ->
 %%% ============================================================================
 
 module_functions() ->
-    [module_functions2(Mod) || {Mod, _FPath} <- code:all_loaded()].
+    lists:sort(
+        [module_functions2(Mod) || {Mod, _FPath} <- code:all_loaded()]
+    ).
 
 module_functions2(Mod) when is_atom(Mod) ->
     Exports = Mod:module_info(exports),
@@ -207,7 +209,7 @@ when_process_is_unregistered(ProcName, Fn) ->
 ensure_dbg_started({Eb_Node, Eb_pid}, Max_queue_len) ->
     % restart dbg
     when_process_is_unregistered(dbg, fun dbg:start/0),
-    StartFn = 
+    StartFn =
         fun() -> 
             Pid = proc_lib:spawn(?MODULE, erlyberly_tcollector, [Eb_Node, Eb_pid, Max_queue_len]),
             register(erlyberly_tcollector, Pid),
@@ -247,9 +249,8 @@ erlyberly_tcollector(Node, Pid, Max_queue_len) when is_integer(Max_queue_len) ->
     % apply a trace on the returns of the code module, so we can listen for 
     % code reloads, a code reload removes all traces on that module so when we
     % receive this message, reapply all traces for that module
-    dbg:p(all, [c, timestamp]),
-    dbg:tp(code, x),
-
+    {ok,_} = dbg:p(all, [c, timestamp]),
+    {ok,_} = dbg:tp(code, x),
     erlyberly_tcollector2(#tcollector{ ui_pid = Pid,
                                        max_queue_len = Max_queue_len }).
 

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -623,7 +623,7 @@ seq_trace_match_spec(_) ->
 %%
 xref_analysis(Ignore_mods, M,F,A) when is_integer(A) ->
     Call_stack_set = gb_sets:new(),
-    xref_analysis2({M,F,A}, gb_sets:from_list(Ignore_mods), Call_stack_set, []).
+    catch xref_analysis2({M,F,A}, gb_sets:from_list(Ignore_mods), Call_stack_set, []).
 
 %%
 xref_analysis2(MFA, Ignore_mods_set, All_calls, Call_stack) ->
@@ -631,11 +631,17 @@ xref_analysis2(MFA, Ignore_mods_set, All_calls, Call_stack) ->
         true ->
             {MFA, []};
         false ->
-            {ok, Calls} = xref:analyze(?erlyberly_xref, {call, MFA}),
-            All_calls2 = gb_sets:add(MFA, All_calls),
-            Analysed_calls =
-                [xref_analysis2(X_mfa, Ignore_mods_set, All_calls2, [MFA | Call_stack]) || X_mfa <- Calls, not is_xref_recursion(MFA, X_mfa)],
-            {MFA, Analysed_calls}
+            %% analyse may not return ok if the module was not compiled with
+            %% the debug_info flag
+            case xref:analyze(?erlyberly_xref, {call, MFA}) of
+                {ok, Calls} ->
+                    All_calls2 = gb_sets:add(MFA, All_calls),
+                    Analysed_calls =
+                        [xref_analysis2(X_mfa, Ignore_mods_set, All_calls2, [MFA | Call_stack]) || X_mfa <- Calls, not is_xref_recursion(MFA, X_mfa)],
+                    {ok, MFA, Analysed_calls};
+                Error ->
+                    throw(Error)
+            end
     end.
 
 %%
@@ -647,9 +653,33 @@ is_xref_recursion(_,_) ->
 %%
 ensure_xref_started() ->
     catch xref:stop(?erlyberly_xref),
-    {ok, _} = xref:start(?erlyberly_xref),
-    Excluded = ["asn1ct", "/ct-", "dialyzer", "diameter", "hipe", "httpd", "megaco", "xmerl", "wx-"],
-    [xref:add_directory(?erlyberly_xref, Dir) || Dir <- code:get_path(), not dir_contains(Dir, Excluded)],
+    {ok, _} = xref:start(?erlyberly_xref, [{verbose, false},{warnings, false}]),
+    Excluded = [
+        "/appmon-", "/asn1-",
+        "/common_test-", "/compiler-", "/cos", "/crypto-", "/ct-",
+        "/debugger-", "/dialyzer", "/diameter",
+        "/edoc", "/eldap", "/erl_docgen", "/erl_interface-", "/erts", "/et-", "/eunit",
+        "/gs-",
+        "/hipe", "/httpd",
+        "/ic-", "/inets",
+        "/jinterface",
+        "/kernel",
+        "/megaco", "/mnesia",
+        "/observer-", "/odbc", "/orber-", "/os_mon", "/otp_mibs",
+        "/parsetools", "/percept-", "/pman", "/public_key",
+        "/reltool", "/runtime_tools",
+        "/sasl", "/snmp", "/ssh", "/ssl", "/stdlib", "/syntax_tools",
+        "/test_server", "/toolbar", "/tools", "/tv-", "/typer",
+        "/webtool", "/wx-",
+        "/xmerl"
+    ],
+    CodePaths =[Dir || Dir <- lists:sort(code:get_path()), not dir_contains(Dir, Excluded)],
+    % [io:format("XREF CODE PATHS ~s~n", [XXX]) || XXX <- CodePaths],
+    {_TimeUs, _} = timer:tc(fun() ->
+        [xref:add_directory(?erlyberly_xref, P) || P <- CodePaths]
+    end),
+    % io:format("TIME ~p",[_TimeUs]),
+    [xref:add_directory(?erlyberly_xref, P) || P <- CodePaths],
     {erlyberly_xref_started}.
 
 dir_contains(_, []) ->

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -232,9 +232,6 @@ store_trace(Trace) ->
     ui_pid,
 
     %%
-    logs = [],
-
-    %%
     traces = [],
 
     %% the maximum message queue length that the collector can accrue before


### PR DESCRIPTION
Add a version to the Maven exec plugin to avoid the warning about stable builds.

A bad RPC was causing loaded modules to not appear until the first trace was made during the session.

Improve error handling when requesting an xref call graph.

Filter all OTP paths from the xref analysis.

Fix module pane resize on start up, using the last configured width.