### PR TITLE
Check if a module is already loaded before loading it from filter input

### DIFF
--- a/src/main/java/erlyberly/DbgView.java
+++ b/src/main/java/erlyberly/DbgView.java
@@ -31,7 +31,6 @@ import com.ericsson.otp.erlang.OtpErlangObject;
 import com.ericsson.otp.erlang.OtpErlangTuple;
 
 import de.jensd.fx.fontawesome.AwesomeIcon;
-import erlyberly.node.OtpUtil;
 import floatyfield.FloatyFieldView;
 import javafx.application.Platform;
 import javafx.beans.Observable;
@@ -318,7 +317,7 @@ public class DbgView implements Initializable {
             long delayMillis = 1000;
             scheduledModuleLoadFuture = ErlyBerly.scheduledIO(delayMillis, () -> {
                 try {
-                    ErlyBerly.nodeAPI().loadModule(OtpUtil.atom(moduleName));
+                    ErlyBerly.nodeAPI().tryLoadModule(moduleName);
                 }
                 catch (Exception e1) {
                     e1.printStackTrace();

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -69,6 +69,10 @@ import javafx.collections.ObservableList;
 
 public class NodeAPI {
 
+    private static final OtpErlangAtom TRY_LOAD_MODULE_ATOM = atom("try_load_module");
+
+    private static final OtpErlangAtom ERROR_ATOM = atom("error");
+
     private static final OtpErlangAtom ERLYBERLY_TRACE_OVERLOAD_ATOM = atom("erlyberly_trace_overload");
 
     private static final String ERLYBERLY = "erlyberly";
@@ -750,13 +754,13 @@ public class NodeAPI {
      * to the code module will see the loaded module and send a message to erlyberly,
      * which will display it in the tree of modules.
      */
-    public void loadModule(OtpErlangAtom moduleNameAtom) throws OtpErlangException, IOException {
+    public void tryLoadModule(String moduleNameAtom) throws OtpErlangException, IOException {
         assert moduleNameAtom != null : "module name string is null";
         assert !"".equals(moduleNameAtom) : " module name string is empty";
         assert !Platform.isFxApplicationThread() : CANNOT_RUN_THIS_METHOD_FROM_THE_FX_THREAD;
         OtpErlangObject result = nodeRPC()
-                .blockingRPC(atom("code"), atom("ensure_loaded"), list(moduleNameAtom));
-        assert isTupleTagged(atom("module"), result) || isTupleTagged(atom("error"), result) : result;
+                .blockingRPC(ERLYBERLY_ATOM, TRY_LOAD_MODULE_ATOM, list(atom(moduleNameAtom)));
+        assert isTupleTagged(MODULE_ATOM, result) || isTupleTagged(ERROR_ATOM, result) : result;
     }
 
     public RpcCallback<TraceLog> getTraceLogCallback() {

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -21,17 +21,18 @@
 -export([collect_trace_logs/0]).
 -export([ensure_dbg_started/2]).
 -export([ensure_xref_started/0]).
--export([saleyn_fun_src/1]).
 -export([get_abstract_code/1]).
 -export([get_process_state/1]).
 -export([get_source_code/1]).
 -export([load_modules_on_path/1]).
 -export([module_functions/0]).
 -export([process_info/0]).
+-export([saleyn_fun_src/1]).
 -export([seq_trace/5]).
 -export([start_trace/5]).
 -export([stop_trace/4]).
 -export([stop_traces/0]).
+-export([try_load_module/1]).
 -export([xref_analysis/4]).
 
 %% exported for spawned processes
@@ -695,6 +696,15 @@ dir_contains(Dir, [Str|Tail]) ->
     case string:str(Dir, Str) of
         0 -> dir_contains(Dir, Tail);
         _ -> true
+    end.
+
+%% load a module if it is not already loaded
+try_load_module(Module_name) when is_atom(Module_name) ->
+    case code:is_loaded(Module_name) of
+        false ->
+            code:ensure_loaded(Module_name);
+        {file, _} ->
+            ok
     end.
 
 %%% ============================================================================


### PR DESCRIPTION
Before this change, every time filter input is made then erlyberly will attempt to load that as a module. This helps to quickly trace modules that are not loaded yet in non-embedded releases. However, each input would reset the module tree making selection very difficult.

Now, erlyberly checks on the remote node that the module is not loaded before attempting to load it, so no call back for the module load is made when changing the filter for one module multiple times.