### PR TITLE
Fix maps in tree view

### DIFF
--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -228,7 +228,8 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                     continue;
                 String keyStr = f.mapKeyToString(e.getKey());
                 String valStr = f.toString(e.getValue());
-                if (valStr.length() < 50) {
+                // Inline short values that are not maps
+                if (!((OtpErlangObject)e.getValue() instanceof OtpErlangMap) && (valStr.length() < 50 )) {
                     TreeItem<TermTreeItem> key = new TreeItem<>(new TermTreeItem(e.getKey(), valStr));
                     key.setGraphic(recordLabel(keyStr));
                     mapNode.getChildren().add(key);


### PR DESCRIPTION
Maps in tree view were not expandable if their stringified length was
less than 50 characters. This commit fixes that.

Example when tracing the following call

`application:set_env(x, y, #{a=>1, c => #{<<"b">> => <<"12345678901234567890123456789012345678901234567890">>}}).`

Old, wrong behaviour:

<img width="291" alt="screen shot 2018-01-22 at 19 32 02" src="https://user-images.githubusercontent.com/1858479/35237703-c2c235ec-ffab-11e7-8c23-bdc292047f9e.png">

New, good behaviour:

<img width="534" alt="screen shot 2018-01-22 at 19 33 41" src="https://user-images.githubusercontent.com/1858479/35237724-d3a9956c-ffab-11e7-8dc8-b6185dd81b55.png">





