### PR TITLE
Record Metadata in Function Traces

### DIFF
--- a/src/main/java/erlyberly/DbgController.java
+++ b/src/main/java/erlyberly/DbgController.java
@@ -27,6 +27,7 @@ import com.ericsson.otp.erlang.OtpErlangException;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangTuple;
 
+import erlyberly.node.OtpUtil;
 import erlyberly.node.RpcCallback;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -122,6 +123,8 @@ public class DbgController implements Initializable {
                 ErlyBerly.nodeAPI().startTrace(function, PrefBind.getMaxTraceQueueLengthConfig());
 
                 Platform.runLater(() -> { traces.add(function); });
+
+                ErlyBerly.nodeAPI().loadModuleRecords(OtpUtil.atom(function.getModuleName()));
             }
             catch (Exception ex) {
                 ex.printStackTrace();

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -20,6 +20,7 @@ package erlyberly;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 
+import erlyberly.node.OtpUtil;
 import floatyfield.FloatyFieldView;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -217,7 +218,8 @@ public class DbgTraceView extends VBox {
         resultTermsTreeView = newTermTreeView();
 
         if(result != null) {
-            resultTermsTreeView.populateFromTerm(traceLog.getResultFromMap());
+            String moduleName = traceLog.getModFunc().getModuleName();
+            resultTermsTreeView.populateFromTerm(OtpUtil.atom(moduleName), traceLog.getResultFromMap());
         }
         else {
             WeakChangeListener<Boolean> listener = new WeakChangeListener<Boolean>((o, oldV, newV) -> {

--- a/src/main/java/erlyberly/DbgTraceView.java
+++ b/src/main/java/erlyberly/DbgTraceView.java
@@ -17,6 +17,7 @@
  */
 package erlyberly;
 
+import com.ericsson.otp.erlang.OtpErlangAtom;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangObject;
 
@@ -217,9 +218,10 @@ public class DbgTraceView extends VBox {
 
         resultTermsTreeView = newTermTreeView();
 
+        OtpErlangAtom moduleName = OtpUtil.atom(traceLog.getModFunc().getModuleName());
+
         if(result != null) {
-            String moduleName = traceLog.getModFunc().getModuleName();
-            resultTermsTreeView.populateFromTerm(OtpUtil.atom(moduleName), traceLog.getResultFromMap());
+            resultTermsTreeView.populateFromTerm(moduleName, traceLog.getResultFromMap());
         }
         else {
             WeakChangeListener<Boolean> listener = new WeakChangeListener<Boolean>((o, oldV, newV) -> {
@@ -231,7 +233,7 @@ public class DbgTraceView extends VBox {
         }
 
         argTermsTreeView = newTermTreeView();
-        argTermsTreeView.populateFromListContents((OtpErlangList)args);
+        argTermsTreeView.populateFromListContents(moduleName, (OtpErlangList)args);
 
         SplitPane splitPane, splitPaneH;
 

--- a/src/main/java/erlyberly/ModFuncContextMenu.java
+++ b/src/main/java/erlyberly/ModFuncContextMenu.java
@@ -275,7 +275,7 @@ public class ModFuncContextMenu extends ContextMenu {
        String moduleName = mf.getModuleName();
        ErlyBerly.runIO(() -> {
            try{
-               final String title;
+                final String title;
                 String modSrc;
                 if(mf.isModule()) {
                     modSrc = fetchModuleCode(menuItemClicked, moduleName);

--- a/src/main/java/erlyberly/StackTraceView.java
+++ b/src/main/java/erlyberly/StackTraceView.java
@@ -27,6 +27,7 @@ import com.ericsson.otp.erlang.OtpErlangTuple;
 
 import erlyberly.StackTraceView.ErlyberlyStackTraceElement;
 import erlyberly.node.OtpUtil;
+import javafx.application.Platform;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -53,16 +54,20 @@ public class StackTraceView extends ListView<ErlyberlyStackTraceElement> {
                             if(stackElement.isError())
                                 return;
                             ModFunc mf = stackElement.getModFunc();
-                            try {
-                                String source = ErlyBerly.nodeAPI().moduleFunctionSourceCode(
-                                        mf.getModuleName(), mf.getFuncName(), mf.getArity());
-                                ErlyBerly.showPane(
-                                    "Crash Report Stack",
-                                    ErlyBerly.wrapInPane(new CodeView(source))
-                                );
-                            } catch (Exception e1) {
-                                e1.printStackTrace();
-                            }
+                            ErlyBerly.runIO(() -> {
+                                try {
+                                    String source = ErlyBerly.nodeAPI().moduleFunctionSourceCode(
+                                            mf.getModuleName(), mf.getFuncName(), mf.getArity());
+                                    Platform.runLater(() -> {
+                                        ErlyBerly.showPane(
+                                            "Crash Report Stack",
+                                            ErlyBerly.wrapInPane(new CodeView(source))
+                                        );
+                                    });
+                                } catch (Exception e1) {
+                                    e1.printStackTrace();
+                                }
+                            });
                         });
                     }
 

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -174,8 +174,16 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                 }
                 else if(isRecordField(obj)) {
                     tupleItem = new TreeItem<>(new TermTreeItem(obj, " "));
-                    OtpErlangString recordField = (OtpErlangString) OtpUtil.tupleElement(1, obj);
-                    tupleItem.setGraphic(recordLabel(recordField.stringValue() + " =  "));
+                    String recordField = "";
+                    OtpErlangObject recordFieldNameObj = OtpUtil.tupleElement(1, obj);
+                    // do not toString an OtpErlangString because that will add the quotes around it
+                    if(recordFieldNameObj instanceof OtpErlangString) {
+                        recordField = ((OtpErlangString)recordFieldNameObj).stringValue();
+                    }
+                    else {
+                        recordField = recordFieldNameObj.toString();
+                    }
+                    tupleItem.setGraphic(recordLabel(recordField + " = "));
                     tupleItem.setExpanded(true);
 
                     parent.getChildren().add(tupleItem);

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -120,10 +120,14 @@ public class TermTreeView extends TreeView<TermTreeItem> {
         }
     }
 
-    public void populateFromListContents(OtpErlangList list) {
+    public void populateFromListContents(OtpErlangAtom moduleName, OtpErlangList list) {
         for (OtpErlangObject a : list) {
-            populateFromTerm(a);
+            populateFromTerm(moduleName, a);
         }
+    }
+
+    public void populateFromListContents(OtpErlangList list) {
+        populateFromListContents(null, list);
     }
 
     public void populateFromTerm(OtpErlangObject obj) {

--- a/src/main/java/erlyberly/TermTreeView.java
+++ b/src/main/java/erlyberly/TermTreeView.java
@@ -28,6 +28,7 @@ import com.ericsson.otp.erlang.OtpErlangFun;
 import com.ericsson.otp.erlang.OtpErlangList;
 import com.ericsson.otp.erlang.OtpErlangMap;
 import com.ericsson.otp.erlang.OtpErlangObject;
+import com.ericsson.otp.erlang.OtpErlangString;
 import com.ericsson.otp.erlang.OtpErlangTuple;
 
 import erlyberly.format.TermFormatter;
@@ -169,7 +170,8 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                 }
                 else if(isRecordField(obj)) {
                     tupleItem = new TreeItem<>(new TermTreeItem(obj, " "));
-                    tupleItem.setGraphic(recordLabel(OtpUtil.tupleElement(1, obj) + " =  "));
+                    OtpErlangString recordField = (OtpErlangString) OtpUtil.tupleElement(1, obj);
+                    tupleItem.setGraphic(recordLabel(recordField.stringValue() + " =  "));
                     tupleItem.setExpanded(true);
 
                     parent.getChildren().add(tupleItem);
@@ -185,7 +187,6 @@ public class TermTreeView extends TreeView<TermTreeItem> {
                     OtpErlangTuple objTuple = (OtpErlangTuple) obj;
                     if((recordNames = findRecordDef(objTuple)) != null) {
                         String recordNameText = "#" + OtpUtil.tupleElement(0, obj) + " ";
-
                         tupleItem = new TreeItem<>(new TermTreeItem(obj, f.tupleLeftParen()));
                         tupleItem.setGraphic(recordLabel(recordNameText));
                         parent.getChildren().add(tupleItem);

--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -767,6 +767,8 @@ public class NodeAPI {
 
 
     public void loadModuleRecords(OtpErlangAtom moduleName) throws OtpErlangException, IOException {
+        if(recordManager.isModuleManaged(moduleName))
+            return;
         OtpErlangObject result = nodeRPC()
                 .blockingRPC(ERLYBERLY_ATOM, atom("load_module_records"), list(moduleName));
         assert isTupleTagged(OK_ATOM, result) : result;

--- a/src/main/java/erlyberly/node/RecordManager.java
+++ b/src/main/java/erlyberly/node/RecordManager.java
@@ -1,0 +1,58 @@
+package erlyberly.node;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.ericsson.otp.erlang.OtpErlangAtom;
+
+public class RecordManager {
+    private final ConcurrentHashMap<RecordKey, List<String>> records = new ConcurrentHashMap<>();
+
+    public List<String> get(Object key) {
+        return records.get(key);
+    }
+
+    public List<String> put(RecordKey key, List<String> value) {
+        return records.put(key, value);
+    }
+
+    public static class RecordKey {
+        private final OtpErlangAtom module, recordName;
+
+        public RecordKey(OtpErlangAtom module, OtpErlangAtom recordName) {
+            this.module = module;
+            this.recordName = recordName;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((module == null) ? 0 : module.hashCode());
+            result = prime * result + ((recordName == null) ? 0 : recordName.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            RecordKey other = (RecordKey) obj;
+            if (module == null) {
+                if (other.module != null)
+                    return false;
+            } else if (!module.equals(other.module))
+                return false;
+            if (recordName == null) {
+                if (other.recordName != null)
+                    return false;
+            } else if (!recordName.equals(other.recordName))
+                return false;
+            return true;
+        }
+    }
+}

--- a/src/main/java/erlyberly/node/RecordManager.java
+++ b/src/main/java/erlyberly/node/RecordManager.java
@@ -1,6 +1,7 @@
 package erlyberly.node;
 
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.ericsson.otp.erlang.OtpErlangAtom;
@@ -54,5 +55,13 @@ public class RecordManager {
                 return false;
             return true;
         }
+    }
+
+    public boolean isModuleManaged(OtpErlangAtom moduleName) {
+        for (Entry<RecordKey, List<String>> entry : records.entrySet()) {
+            if(moduleName.equals(entry.getKey().module))
+                return true;
+        }
+        return false;
     }
 }

--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -155,6 +155,8 @@ record_fields([{record_field,_,{atom,_,Field}} | Fs]) ->
     [Field | record_fields(Fs)];
 record_fields([{record_field,_,{atom,_,Field},_} | Fs]) ->
     [Field | record_fields(Fs)];
+record_fields([{typed_record_field, {record_field,_,{atom,_,Field},_}, _} | Fs]) ->
+    [Field | record_fields(Fs)];
 record_fields([]) ->
     [].
 


### PR DESCRIPTION
Before this change, records and record fields would be highlighted for gen_server callbacks. Now records that are defined in the traced module (inc. included header files) will be highlighted in function traces.

When a trace call is made, the modules beam file is parsed and record AST is pulled out and stored in memory in the UI. When the term is displayed in the tree, if a matching record name within the traced module is found then the metadata labels are added in the tree.

<img width="1548" alt="screen shot 2018-01-27 at 17 07 24" src="https://user-images.githubusercontent.com/213455/35474493-d3fa2e80-0386-11e8-84d9-f6da3f5b0097.png">

