### PR TITLE
Run CI on JDK 9 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
 after_success:
   - ./mvnw assembly:single license:check


### PR DESCRIPTION
Compiling with JDK 9 works. Though with JDK 9 it fails to start for me - it is starting with JDK 8.

Out of scope for this PR, though hooking in the CI some smoke test of connecting to a node would be very useful.