### PR TITLE
do not fail when writing properties

### DIFF
--- a/src/main/java/erlyberly/PrefBind.java
+++ b/src/main/java/erlyberly/PrefBind.java
@@ -104,7 +104,7 @@ public class PrefBind {
             //props.store(new FileOutputStream(erlyberlyConfig), " erlyberly at https://github.com/andytill/erlyberly");
             new TomlWriter().write(props, new FileOutputStream(erlyberlyConfig));
         }
-        catch (IOException e) {
+        catch (IOException | NoClassDefFoundError e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
This is a workaround for https://github.com/andytill/erlyberly/issues/163

Writing properties is not crucial to continue operation, so we should just continue if TomlWriter failed to load