### PR TITLE
compile erl remotely if beam loading failed

### DIFF
--- a/src/main/java/erlyberly/node/NodeAPI.java
+++ b/src/main/java/erlyberly/node/NodeAPI.java
@@ -445,8 +445,13 @@ public class NodeAPI {
             loadErlyberlyError(result);
         }
         String remotePathNoErl = ERLYBERLY_REMOTE_ERL_PATH.replaceFirst(".erl$","");
-        result = nodeRPC().blockingRPC(atom("compile"), atom("file"), list(remotePathNoErl, list()));
-        if (!(tuple(atom("ok"), ERLYBERLY_ATOM).equals(result))) {
+        result = nodeRPC().blockingRPC(atom("compile"), atom("file"), list(remotePathNoErl, list(atom("binary"))));
+        if (!(result instanceof OtpErlangTuple && atom("ok").equals(((OtpErlangTuple)result).elementAt(0)))) {
+            loadErlyberlyError(result);
+        }
+        OtpErlangBinary beamBin = (OtpErlangBinary) ((OtpErlangTuple)result).elementAt(2);
+        result = nodeRPC().blockingRPC(atom("code"), atom("load_binary"), list(ERLYBERLY_ATOM, ERLYBERLY_ATOM, beamBin));
+        if (!tuple(atom("module"), ERLYBERLY_ATOM).equals(result)) {
             loadErlyberlyError(result);
         }
         nodeRPC().blockingRPC(atom("file"), atom("delete"), list(ERLYBERLY_REMOTE_ERL_PATH));


### PR DESCRIPTION
It can be tricky to trace with erlyberly when the system running erlyberly has newer version of Erlang/OTP installed than the target system. Erlyberly may then fail to load the erlyberly.beam on the remote system.

This patch will prevent Erlyberly from immediately failing if the .beam file failed to load, but instead will try to copy the corresponding .erl file to the target system and compile it on the target system, which allows to overcome the version mismatch.