### PR TITLE
try to get abstract code from source if not available in beam

### DIFF
--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -169,16 +169,13 @@ load_module_forms(Mod) ->
             CompileInfo = Mod:module_info(compile),
             case [ Src || {source, Src} <- CompileInfo ] of
                 [SrcPath] ->
-                    Opts = [ {includes, IPath}
-                             || {options, COpts} <- CompileInfo,
-                                {i, IPath} <- COpts ] ++
-                           [ {macros, Macro}
-                             || {options, COpts} <- CompileInfo,
-                                {d, Macro} <- COpts ] ++
-                           [ {macros, Macro, Value}
-                             || {options, COpts} <- CompileInfo,
-                                {d, Macro, Value} <- COpts ],
-                    epp:parse_file(SrcPath, Opts);
+                    Includes = [IPath || {options, COpts} <- CompileInfo,
+                                          {i, IPath} <- COpts],
+                    Macros = [Macro || {options, COpts} <- CompileInfo,
+                                       {d, Macro} <- COpts] ++
+                             [{Macro, Value} || {options, COpts} <- CompileInfo,
+                                                {d, Macro, Value} <- COpts],
+                    epp:parse_file(SrcPath, Includes, Macros);
                 [] -> Error
             end
     end.


### PR DESCRIPTION
In order to get abstract code from beam it needs to be compiled with [debug_info]. This is not always the case, however it may be possible that the source is still available by the path indicated in module_info.