### PR TITLE
Fix typed record fields

### DIFF
--- a/src/main/resources/erlyberly/beam/erlyberly.erl
+++ b/src/main/resources/erlyberly/beam/erlyberly.erl
@@ -155,6 +155,8 @@ record_fields([{record_field,_,{atom,_,Field}} | Fs]) ->
     [Field | record_fields(Fs)];
 record_fields([{record_field,_,{atom,_,Field},_} | Fs]) ->
     [Field | record_fields(Fs)];
+record_fields([{typed_record_field, {record_field,_,{atom,_,Field}}, _} | Fs]) ->
+    [Field | record_fields(Fs)];
 record_fields([{typed_record_field, {record_field,_,{atom,_,Field},_}, _} | Fs]) ->
     [Field | record_fields(Fs)];
 record_fields([]) ->


### PR DESCRIPTION
Clause was missing. This is still Erlang 20 format. Fixing Erlang 21
will be another PR.