### PR TITLE
Add missing JavaFX dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,35 @@
   </properties>
 
   <dependencies>
+     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx</artifactId>
+      <version>16-ea+1</version>
+      <type>pom</type>
+    </dependency>
+     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-base</artifactId>
+      <version>16-ea+1</version>
+      <type>pom</type>
+    </dependency>
+     <dependency> <groupId>org.openjfx</groupId> <artifactId>javafx-graphics</artifactId> <version>16-ea+1</version> <type>pom</type> </dependency>
+     <dependency> <groupId>org.openjfx</groupId> <artifactId>javafx-controls</artifactId> <version>16-ea+1</version> <type>pom</type> </dependency>
+     <dependency> <groupId>org.openjfx</groupId> <artifactId>javafx-fxml</artifactId> <version>16-ea+1</version> <type>pom</type> </dependency>
+     <dependency> <groupId>org.openjfx</groupId> <artifactId>javafx-media</artifactId> <version>16-ea+1</version> <type>pom</type> </dependency>
+     <dependency> <groupId>org.openjfx</groupId> <artifactId>javafx-media</artifactId> <version>16-ea+1</version> <type>pom</type> </dependency>
+     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-maven-archetypes</artifactId>
+      <version>0.0.5</version>
+      <type>pom</type>
+    </dependency>
+     <dependency>
+      <groupId>org.openjfx</groupId>
+      <artifactId>javafx-archetype-fxml</artifactId>
+      <version>0.0.5</version>
+      <type>pom</type>
+    </dependency>
     <dependency>
       <groupId>com.github.andytill</groupId>
       <artifactId>jinterface</artifactId>
@@ -76,6 +105,15 @@
           </archive>
         </configuration>
       </plugin>     
+
+      <plugin>
+        <groupId>org.openjfx</groupId>
+        <artifactId>javafx-maven-plugin</artifactId>
+        <version>0.0.4</version>
+        <configuration>
+              <mainClass>erlyberly.ErlyBerly</mainClass>
+        </configuration>
+      </plugin>
   
       <plugin>
        <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Hello! 

I was recently trying to get this up and running on an Ubuntu machine and I realized that I couldn't get it to build because it was missing some dependencies.

After playing around with the POM, it eventually compiled and run. It still has an issue with the latest versions of OTP, as seen in #175, but it seemed to run given you have JavaFX installed globally and use the Maven plugin: `mvn javafx:run`.

Opening this as a draft to have a chat about it :smiley: 
